### PR TITLE
Feature - wavelet denoising - wavelet decomposer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
 configuration:
   - Debug
   - Release
-version: 3.6.2.{build}
+version: 3.7.0.{build}
 
 init:
 - cmd: echo Project - %APPVEYOR_PROJECT_NAME%

--- a/src/Spectre.libWavelet.Tests/ConvolutionTest.cpp
+++ b/src/Spectre.libWavelet.Tests/ConvolutionTest.cpp
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 #include "Spectre.libWavelet\Convolution.h"
+#include "Spectre.libFunctional\Range.h"
 
 namespace
 {
@@ -31,22 +32,13 @@ namespace
 
     class ConvolutionTest : public ::testing::Test
     {
-    public:
-        void InitializeSignal(Signal& signal)
-        {
-            for (unsigned i = 0; i < signal.size(); i++)
-            {
-                signal[i] = (DataType)i;
-            }
-        }
     protected:
         Convolution convolution;
     };
 
     TEST_F(ConvolutionTest, properly_convolves_the_kernel_over_a_signal)
     {
-        Signal signal(10);
-        InitializeSignal(signal);
+        Signal signal = spectre::core::functional::range<DataType>(10);
         Kernel kernel = { 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0 };
         Signal result = convolution.Convolve(kernel, signal);
         Signal correctResult = { 0.0, 0.0, 1.0, 4.0, 10.0, 20.0, 35.0, 56.0, 84.0, 112.0 };

--- a/src/Spectre.libWavelet.Tests/ConvolutionTest.cpp
+++ b/src/Spectre.libWavelet.Tests/ConvolutionTest.cpp
@@ -31,16 +31,25 @@ namespace
 
     class ConvolutionTest : public ::testing::Test
     {
+    public:
+        void InitializeSignal(Signal& signal)
+        {
+            for (unsigned i = 0; i < signal.size(); i++)
+            {
+                signal[i] = (DataType)i;
+            }
+        }
     protected:
         Convolution convolution;
     };
 
     TEST_F(ConvolutionTest, properly_convolves_the_kernel_over_a_signal)
     {
-        Signal signal = { 1.0, 2.0, 3.0, 4.0 };
-        Signal kernel = { -0.5, 1.0 };
+        Signal signal(10);
+        InitializeSignal(signal);
+        Kernel kernel = { 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0 };
         Signal result = convolution.Convolve(kernel, signal);
-        Signal correctResult = { -0.5, 0.0, 0.5, 1.0 };
+        Signal correctResult = { 0.0, 0.0, 1.0, 4.0, 10.0, 20.0, 35.0, 56.0, 84.0, 112.0 };
         ASSERT_EQ(correctResult, result);
     }
 }

--- a/src/Spectre.libWavelet.Tests/Spectre.libWavelet.Tests.vcxproj
+++ b/src/Spectre.libWavelet.Tests/Spectre.libWavelet.Tests.vcxproj
@@ -80,7 +80,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(OutputPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>Spectre.libWavelet.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Spectre.libWavelet.lib;Spectre.libFunctional.lib;Spectre.libException.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -95,7 +95,7 @@
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(OutputPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>Spectre.libWavelet.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Spectre.libWavelet.lib;Spectre.libFunctional.lib;Spectre.libException.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -114,7 +114,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(OutputPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>Spectre.libWavelet.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Spectre.libWavelet.lib;Spectre.libFunctional.lib;Spectre.libException.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -133,7 +133,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(OutputPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>Spectre.libWavelet.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Spectre.libWavelet.lib;Spectre.libFunctional.lib;Spectre.libException.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/Spectre.libWavelet.Tests/Spectre.libWavelet.Tests.vcxproj
+++ b/src/Spectre.libWavelet.Tests/Spectre.libWavelet.Tests.vcxproj
@@ -141,6 +141,7 @@
     <ClCompile Include="MeanAbsoluteDeviationNoiseEstimatorTest.cpp" />
     <ClCompile Include="ConvolutionTest.cpp" />
     <ClCompile Include="SoftThresholderTest.cpp" />
+    <ClCompile Include="WaveletDecomposerRefTest.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Spectre.libWavelet.Tests/Spectre.libWavelet.Tests.vcxproj.filters
+++ b/src/Spectre.libWavelet.Tests/Spectre.libWavelet.Tests.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClCompile Include="ConvolutionTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="WaveletDecomposerRefTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Spectre.libWavelet.Tests/WaveletDecomposerRefTest.cpp
+++ b/src/Spectre.libWavelet.Tests/WaveletDecomposerRefTest.cpp
@@ -1,0 +1,171 @@
+/*
+* WaveletDecomposerRefTest.cpp
+* Tests whether the signal is properly decomposed by the reference 
+* implementation.
+*
+Copyright 2018 Michal Gallus
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <gtest/gtest.h>
+#include "Spectre.libWavelet\WaveletDecomposerRef.h"
+
+namespace
+{
+    using namespace spectre::algorithm::wavelet;
+
+    static void CompareVectors(const std::vector<DataType>& estimate, const std::vector<DataType>& correct)
+    {
+        constexpr DataType maxAbsoluteError = 0.0001;
+        for (unsigned i = 0; i < estimate.size(); i++)
+        {
+            ASSERT_NEAR(estimate[i], correct[i], maxAbsoluteError);
+        }
+    }
+
+    TEST(WaveletDecomposerInitialization, initializes)
+    {
+        EXPECT_NO_THROW(WaveletDecomposerRef());
+    }
+
+    class WaveletDecomposerRefTest : public ::testing::Test
+    {
+    public:
+        WaveletDecomposerRefTest()
+        {
+            lastRowLastHighFrequencyResult = {
+                -1.00930961719589e-05,
+                0.000631661429085606,
+                0.00363953257484134,
+                -0.0349096779749494,
+                0.0939060392824094,
+                -0.573668491474043,
+                1.48135002884348,
+                -1.25125371723593,
+                -0.0680747992002441,
+                0.371157080651903,
+                0.0638308206668811,
+                -0.0652726295392059,
+                -0.0213226552393410,
+                -3.09968872155731e-06,
+                0.0
+            };
+            firstRowLastHighFrequencyResult = {
+                0.0,
+                -8.84442489411620e-06,
+                0.000586138712079808,
+                0.00366319641253592,
+                -0.0337088162678507,
+                0.0882423835249452,
+                -0.562277648805622,
+                1.47065650410807,
+                -1.24839451703031,
+                -0.0660665610544188,
+                0.370413811253544,
+                0.0633207123092398,
+                -0.0651742255517986,
+                -0.0212504983010336,
+                -1.63488447864066e-06
+            };
+            firstHighFrequencyResult = {
+                0,
+                -0.230377813308897,
+                0.254090943935123,
+                0.107678933249283,
+                -0.0667168468534168,
+                -0.0540778152370236,
+                -0.0105974017850692,
+                -2.22044604925031e-16,
+                -2.22044604925031e-16,
+                -8.88178419700125e-16,
+                2.30377813308897,
+                -4.61430975913130,
+                1.21002916292327,
+                1.63627886777771,
+                -0.0596734693105170,
+                -0.380726319282519,
+                -0.0953766160656215
+            };
+            firstLowFrequencyResult = {
+                0.0,
+                -4.06844404044861e-07,
+                2.69624376778159e-05,
+                0.000170805548639498,
+                -0.00170291259939498,
+                0.00309960587361391,
+                -0.0165956761940691,
+                0.0479600502210081,
+                0.0561611188212727,
+                -0.339939690673109,
+                -0.0487037936781232,
+                1.23299325679310,
+                1.41702876032074,
+                0.461966379081157,
+                3.55408918941385e-05,
+                0.0
+            };
+            lastLowFrequencyResult = {
+                -4.64283404088808e-07,
+                2.90564870809657e-05,
+                0.000170041467736160,
+                -0.00176998109340235,
+                0.00336519663747599,
+                -0.0167679988715969,
+                0.0469668204068491,
+                0.0577080776967957,
+                -0.338551325051386,
+                -0.0523643871799257,
+                1.23076472595957,
+                1.41934784856588,
+                0.463535004863161,
+                6.73843951653069e-05,
+                0.0,
+                0.0
+            };
+        }
+
+        void InitializeSignal(Signal& signal)
+        {
+            for (unsigned i = 0; i < signal.size(); i++)
+            {
+                signal[i] = (DataType)i;
+            }
+        }
+
+    protected:
+        WaveletDecomposerRef decomposer;
+        std::vector<DataType> lastRowLastHighFrequencyResult;
+        std::vector<DataType> firstRowLastHighFrequencyResult;
+        std::vector<DataType> firstHighFrequencyResult;
+        std::vector<DataType> firstLowFrequencyResult;
+        std::vector<DataType> lastLowFrequencyResult;
+    };
+
+    TEST_F(WaveletDecomposerRefTest, decomposes_the_signal)
+    {
+        Signal signal(10);
+        InitializeSignal(signal);
+        WaveletCoefficients coefficients = decomposer.Decompose(std::move(signal));
+
+        // Due to high amount of coefficients generated, only a few sets will be
+        // compared
+        CompareVectors(coefficients.data[0][0], firstHighFrequencyResult);
+        CompareVectors(coefficients.data[WAVELET_LEVELS - 1][0], firstRowLastHighFrequencyResult);
+        CompareVectors(coefficients.data[WAVELET_LEVELS - 1][(1 << (WAVELET_LEVELS - 1)) - 1],
+            lastRowLastHighFrequencyResult);
+        CompareVectors(coefficients.data[WAVELET_LEVELS][0], firstLowFrequencyResult);
+        CompareVectors(coefficients.data[WAVELET_LEVELS][(1 << (WAVELET_LEVELS - 1)) - 1],
+            lastLowFrequencyResult);
+    }
+}

--- a/src/Spectre.libWavelet.Tests/WaveletDecomposerRefTest.cpp
+++ b/src/Spectre.libWavelet.Tests/WaveletDecomposerRefTest.cpp
@@ -23,28 +23,29 @@ limitations under the License.
 
 namespace
 {
-    using namespace spectre::algorithm::wavelet;
+using namespace spectre::algorithm::wavelet;
 
-    static void CompareVectors(const std::vector<DataType>& estimate, const std::vector<DataType>& correct)
+static void CompareVectors(const std::vector<DataType>& estimate,
+    const std::vector<DataType>& correct)
+{
+    constexpr DataType maxAbsoluteError = 0.0001;
+    for (unsigned i = 0; i < estimate.size(); i++)
     {
-        constexpr DataType maxAbsoluteError = 0.0001;
-        for (unsigned i = 0; i < estimate.size(); i++)
-        {
-            ASSERT_NEAR(estimate[i], correct[i], maxAbsoluteError);
-        }
+        ASSERT_NEAR(estimate[i], correct[i], maxAbsoluteError);
     }
+}
 
-    TEST(WaveletDecomposerInitialization, initializes)
-    {
-        EXPECT_NO_THROW(WaveletDecomposerRef());
-    }
+TEST(WaveletDecomposerInitialization, initializes)
+{
+    EXPECT_NO_THROW(WaveletDecomposerRef());
+}
 
-    class WaveletDecomposerRefTest : public ::testing::Test
+class WaveletDecomposerRefTest : public ::testing::Test
+{
+public:
+    WaveletDecomposerRefTest()
     {
-    public:
-        WaveletDecomposerRefTest()
-        {
-            lastRowLastHighFrequencyResult = {
+        lastRowLastHighFrequencyResult = {
                 -1.00930961719589e-05,
                 0.000631661429085606,
                 0.00363953257484134,
@@ -61,7 +62,7 @@ namespace
                 -3.09968872155731e-06,
                 0.0
             };
-            firstRowLastHighFrequencyResult = {
+        firstRowLastHighFrequencyResult = {
                 0.0,
                 -8.84442489411620e-06,
                 0.000586138712079808,
@@ -78,7 +79,7 @@ namespace
                 -0.0212504983010336,
                 -1.63488447864066e-06
             };
-            firstHighFrequencyResult = {
+        firstHighFrequencyResult = {
                 0,
                 -0.230377813308897,
                 0.254090943935123,
@@ -97,7 +98,7 @@ namespace
                 -0.380726319282519,
                 -0.0953766160656215
             };
-            firstLowFrequencyResult = {
+        firstLowFrequencyResult = {
                 0.0,
                 -4.06844404044861e-07,
                 2.69624376778159e-05,
@@ -115,7 +116,7 @@ namespace
                 3.55408918941385e-05,
                 0.0
             };
-            lastLowFrequencyResult = {
+        lastLowFrequencyResult = {
                 -4.64283404088808e-07,
                 2.90564870809657e-05,
                 0.000170041467736160,
@@ -133,39 +134,42 @@ namespace
                 0.0,
                 0.0
             };
-        }
-
-        void InitializeSignal(Signal& signal)
-        {
-            for (unsigned i = 0; i < signal.size(); i++)
-            {
-                signal[i] = (DataType)i;
-            }
-        }
-
-    protected:
-        WaveletDecomposerRef decomposer;
-        std::vector<DataType> lastRowLastHighFrequencyResult;
-        std::vector<DataType> firstRowLastHighFrequencyResult;
-        std::vector<DataType> firstHighFrequencyResult;
-        std::vector<DataType> firstLowFrequencyResult;
-        std::vector<DataType> lastLowFrequencyResult;
-    };
-
-    TEST_F(WaveletDecomposerRefTest, decomposes_the_signal)
-    {
-        Signal signal(10);
-        InitializeSignal(signal);
-        WaveletCoefficients coefficients = decomposer.Decompose(std::move(signal));
-
-        // Due to high amount of coefficients generated, only a few sets will be
-        // compared
-        CompareVectors(coefficients.data[0][0], firstHighFrequencyResult);
-        CompareVectors(coefficients.data[WAVELET_LEVELS - 1][0], firstRowLastHighFrequencyResult);
-        CompareVectors(coefficients.data[WAVELET_LEVELS - 1][(1 << (WAVELET_LEVELS - 1)) - 1],
-            lastRowLastHighFrequencyResult);
-        CompareVectors(coefficients.data[WAVELET_LEVELS][0], firstLowFrequencyResult);
-        CompareVectors(coefficients.data[WAVELET_LEVELS][(1 << (WAVELET_LEVELS - 1)) - 1],
-            lastLowFrequencyResult);
     }
+
+    void InitializeSignal(Signal& signal)
+    {
+        for (unsigned i = 0; i < signal.size(); i++)
+        {
+            signal[i] = (DataType)i;
+        }
+    }
+
+protected:
+    WaveletDecomposerRef decomposer;
+    std::vector<DataType> lastRowLastHighFrequencyResult;
+    std::vector<DataType> firstRowLastHighFrequencyResult;
+    std::vector<DataType> firstHighFrequencyResult;
+    std::vector<DataType> firstLowFrequencyResult;
+    std::vector<DataType> lastLowFrequencyResult;
+};
+
+TEST_F(WaveletDecomposerRefTest, decomposes_the_signal)
+{
+    Signal signal(10);
+    InitializeSignal(signal);
+    WaveletCoefficients coefficients = decomposer.Decompose(std::move(signal));
+
+    // Due to high amount of coefficients generated, only a few sets will be
+    // compared
+    CompareVectors(coefficients.data[0][0], firstHighFrequencyResult);
+    CompareVectors(coefficients.data[WAVELET_LEVELS - 1][0],
+        firstRowLastHighFrequencyResult);
+    CompareVectors(
+        coefficients.data[WAVELET_LEVELS - 1][(1 << (WAVELET_LEVELS - 1)) - 1],
+        lastRowLastHighFrequencyResult);
+    CompareVectors(coefficients.data[WAVELET_LEVELS][0], firstLowFrequencyResult);
+    CompareVectors(
+        coefficients.data[WAVELET_LEVELS][(1 << (WAVELET_LEVELS - 1)) - 1],
+        lastLowFrequencyResult);
+}
 }

--- a/src/Spectre.libWavelet.Tests/WaveletDecomposerRefTest.cpp
+++ b/src/Spectre.libWavelet.Tests/WaveletDecomposerRefTest.cpp
@@ -20,6 +20,7 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 #include "Spectre.libWavelet\WaveletDecomposerRef.h"
+#include "Spectre.libFunctional\Range.h"
 
 namespace
 {
@@ -136,14 +137,6 @@ public:
             };
     }
 
-    void InitializeSignal(Signal& signal)
-    {
-        for (unsigned i = 0; i < signal.size(); i++)
-        {
-            signal[i] = (DataType)i;
-        }
-    }
-
 protected:
     WaveletDecomposerRef decomposer;
     std::vector<DataType> lastRowLastHighFrequencyResult;
@@ -155,8 +148,7 @@ protected:
 
 TEST_F(WaveletDecomposerRefTest, decomposes_the_signal)
 {
-    Signal signal(10);
-    InitializeSignal(signal);
+    Signal signal = spectre::core::functional::range<DataType>(10);
     WaveletCoefficients coefficients = decomposer.Decompose(std::move(signal));
 
     // Due to high amount of coefficients generated, only a few sets will be

--- a/src/Spectre.libWavelet/Convolution.cpp
+++ b/src/Spectre.libWavelet/Convolution.cpp
@@ -24,7 +24,7 @@ Convolution::Convolution()
 {
 }
 
-Signal Convolution::Convolve(const Signal& kernel, const Signal &signal)
+Signal Convolution::Convolve(Kernel& kernel, const Signal &signal) const
 {
     std::vector<DataType> convolved(signal.size());
     for (unsigned n = 0u; n < signal.size(); ++n)

--- a/src/Spectre.libWavelet/Convolution.cpp
+++ b/src/Spectre.libWavelet/Convolution.cpp
@@ -24,7 +24,7 @@ Convolution::Convolution()
 {
 }
 
-Signal Convolution::Convolve(Kernel& kernel, const Signal &signal) const
+Signal Convolution::Convolve(const Kernel& kernel, const Signal &signal) const
 {
     std::vector<DataType> convolved(signal.size());
     for (unsigned n = 0u; n < signal.size(); ++n)

--- a/src/Spectre.libWavelet/Convolution.h
+++ b/src/Spectre.libWavelet/Convolution.h
@@ -23,7 +23,7 @@
 
 namespace spectre::algorithm::wavelet
 {
-using Kernel = const std::array<const DataType, 8>;
+using Kernel = std::array<const DataType, 8>;
 
 /// <summary>
 /// Filters the signal using rational transfer function.
@@ -42,6 +42,6 @@ public:
     /// <param name="kernel">Kernel to be used.</param>
     /// <param name="signal">Signal to be convolved.</param>
     /// <returns>Filtered signal.</returns>
-    Signal Convolve(Kernel& kernel, const Signal& signal) const;
+    Signal Convolve(const Kernel& kernel, const Signal& signal) const;
 };
 }

--- a/src/Spectre.libWavelet/Convolution.h
+++ b/src/Spectre.libWavelet/Convolution.h
@@ -17,11 +17,14 @@
    limitations under the License.
 */
 #pragma once
+#include <array>
 #include <span.h>
 #include "DataTypes.h"
 
 namespace spectre::algorithm::wavelet
 {
+using Kernel = const std::array<const DataType, 8>;
+
 /// <summary>
 /// Filters the signal using rational transfer function.
 /// The denominator is set to 1.
@@ -39,6 +42,6 @@ public:
     /// <param name="kernel">Kernel to be used.</param>
     /// <param name="signal">Signal to be convolved.</param>
     /// <returns>Filtered signal.</returns>
-    Signal Convolve(const Signal& kernel, const Signal& signal);
+    Signal Convolve(Kernel& kernel, const Signal& signal) const;
 };
 }

--- a/src/Spectre.libWavelet/DataTypes.h
+++ b/src/Spectre.libWavelet/DataTypes.h
@@ -23,4 +23,6 @@ namespace spectre::algorithm::wavelet
 {
 using DataType = double;
 using Signal = std::vector<DataType>;
+using CoefficientList = std::vector<DataType>;
+using CoefficientsPerLevel = std::vector<CoefficientList>;
 }

--- a/src/Spectre.libWavelet/PrecomputedDaubechiesCoefficients.h
+++ b/src/Spectre.libWavelet/PrecomputedDaubechiesCoefficients.h
@@ -1,6 +1,6 @@
 /*
- * precomputedDaubechies4Coefficientss.h
- * Contains precomputed daubechie filters coefficients.
+ * PrecomputedDaubechies4Coefficients.h
+ * Contains precomputed daubechies filters coefficients.
  *
    Copyright 2018 Michal Gallus
 

--- a/src/Spectre.libWavelet/PrecomputedDaubechiesCoefficients.h
+++ b/src/Spectre.libWavelet/PrecomputedDaubechiesCoefficients.h
@@ -1,5 +1,5 @@
 /*
- * PrecomputedDaubechiesCoefficients.h
+ * precomputedDaubechies4Coefficientss.h
  * Contains precomputed daubechie filters coefficients.
  *
    Copyright 2018 Michal Gallus
@@ -22,7 +22,7 @@
 
 namespace spectre::algorithm::wavelet::precomputed
 {
-constexpr std::array<const DataType, 8> precomputedDaubechiesCoefficient{
+constexpr std::array<const DataType, 8> precomputedDaubechies4Coefficients{
     0.23037781330889653408355854935508,
     0.71484657055291567218091586255468,
     0.63088076792985892105036782595562,
@@ -32,44 +32,44 @@ constexpr std::array<const DataType, 8> precomputedDaubechiesCoefficient{
     0.032883011666885168799989713761533,
     0.010597401785069055987764663484541
 };
-constexpr std::array<const DataType, 8> ReconstructionVlNumerator{
-    precomputedDaubechiesCoefficient[0],
-    precomputedDaubechiesCoefficient[1],
-    precomputedDaubechiesCoefficient[2],
-    -precomputedDaubechiesCoefficient[3],
-    -precomputedDaubechiesCoefficient[4],
-    precomputedDaubechiesCoefficient[5],
-    precomputedDaubechiesCoefficient[6],
-    -precomputedDaubechiesCoefficient[7]
+constexpr std::array<const DataType, 8> ReconstructionLowPassFilter{
+    precomputedDaubechies4Coefficients[0],
+    precomputedDaubechies4Coefficients[1],
+    precomputedDaubechies4Coefficients[2],
+    -precomputedDaubechies4Coefficients[3],
+    -precomputedDaubechies4Coefficients[4],
+    precomputedDaubechies4Coefficients[5],
+    precomputedDaubechies4Coefficients[6],
+    -precomputedDaubechies4Coefficients[7]
 };
-constexpr std::array<const DataType, 8> DecompositionYhNumerator{
-    -precomputedDaubechiesCoefficient[0],
-    precomputedDaubechiesCoefficient[1],
-    -precomputedDaubechiesCoefficient[2],
-    -precomputedDaubechiesCoefficient[3],
-    precomputedDaubechiesCoefficient[4],
-    precomputedDaubechiesCoefficient[5],
-    -precomputedDaubechiesCoefficient[6],
-    -precomputedDaubechiesCoefficient[7]
+constexpr std::array<const DataType, 8> DecompositionHighPassFilter{
+    -precomputedDaubechies4Coefficients[0],
+    precomputedDaubechies4Coefficients[1],
+    -precomputedDaubechies4Coefficients[2],
+    -precomputedDaubechies4Coefficients[3],
+    precomputedDaubechies4Coefficients[4],
+    precomputedDaubechies4Coefficients[5],
+    -precomputedDaubechies4Coefficients[6],
+    -precomputedDaubechies4Coefficients[7]
 };
-constexpr std::array<const DataType, 8> DecompositionYlNumerator{
-    -precomputedDaubechiesCoefficient[7],
-    precomputedDaubechiesCoefficient[6],
-    precomputedDaubechiesCoefficient[5],
-    -precomputedDaubechiesCoefficient[4],
-    -precomputedDaubechiesCoefficient[3],
-    precomputedDaubechiesCoefficient[2],
-    precomputedDaubechiesCoefficient[1],
-    precomputedDaubechiesCoefficient[0]
+constexpr std::array<const DataType, 8> DecompositionLowPassFilter{
+    -precomputedDaubechies4Coefficients[7],
+    precomputedDaubechies4Coefficients[6],
+    precomputedDaubechies4Coefficients[5],
+    -precomputedDaubechies4Coefficients[4],
+    -precomputedDaubechies4Coefficients[3],
+    precomputedDaubechies4Coefficients[2],
+    precomputedDaubechies4Coefficients[1],
+    precomputedDaubechies4Coefficients[0]
 };
-constexpr std::array<const DataType, 8> ReconstructionVhNumerator{
-    -precomputedDaubechiesCoefficient[7],
-    -precomputedDaubechiesCoefficient[6],
-    precomputedDaubechiesCoefficient[5],
-    precomputedDaubechiesCoefficient[4],
-    -precomputedDaubechiesCoefficient[3],
-    -precomputedDaubechiesCoefficient[2],
-    precomputedDaubechiesCoefficient[1],
-    -precomputedDaubechiesCoefficient[0]
+constexpr std::array<const DataType, 8> ReconstructionHighPassFilter{
+    -precomputedDaubechies4Coefficients[7],
+    -precomputedDaubechies4Coefficients[6],
+    precomputedDaubechies4Coefficients[5],
+    precomputedDaubechies4Coefficients[4],
+    -precomputedDaubechies4Coefficients[3],
+    -precomputedDaubechies4Coefficients[2],
+    precomputedDaubechies4Coefficients[1],
+    -precomputedDaubechies4Coefficients[0]
 };
 }

--- a/src/Spectre.libWavelet/Spectre.libWavelet.vcxproj
+++ b/src/Spectre.libWavelet/Spectre.libWavelet.vcxproj
@@ -131,11 +131,13 @@
     <ClInclude Include="MeanAbsoluteDeviationNoiseEstimator.h" />
     <ClInclude Include="PrecomputedDaubechiesCoefficients.h" />
     <ClInclude Include="SoftThresholder.h" />
+    <ClInclude Include="WaveletDecomposerRef.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Convolution.cpp" />
     <ClCompile Include="MeanAbsoluteDeviationNoiseEstimator.cpp" />
     <ClCompile Include="SoftThresholder.cpp" />
+    <ClCompile Include="WaveletDecomposerRef.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Spectre.libWavelet/Spectre.libWavelet.vcxproj.filters
+++ b/src/Spectre.libWavelet/Spectre.libWavelet.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClInclude Include="Convolution.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="WaveletDecomposerRef.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="MeanAbsoluteDeviationNoiseEstimator.cpp">
@@ -39,6 +42,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Convolution.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="WaveletDecomposerRef.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/Spectre.libWavelet/WaveletDecomposerRef.cpp
+++ b/src/Spectre.libWavelet/WaveletDecomposerRef.cpp
@@ -1,0 +1,126 @@
+/*
+* WaveletDecomposerRef.cpp
+* Reference implementation of wavelet decomposer.
+*
+* Bibliography:
+* https://en.wikipedia.org/wiki/Stationary_wavelet_transform#Implementation
+* http://web.iitd.ac.in/~sumeet/WaveletTutorial.pdf
+* http://www.egr.msu.edu/~aviyente/ece802swt.ppt
+*
+Copyright 2018 Michal Gallus
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "WaveletDecomposerRef.h"
+#include "PrecomputedDaubechiesCoefficients.h"
+
+namespace spectre::algorithm::wavelet
+{
+static constexpr size_t ComputeScale(unsigned level)
+{
+    return 1ULL << (level + 1); // 2^(L + 1)
+}
+
+static constexpr size_t CeiledDivision(size_t dividend, size_t divisor)
+{
+    return dividend / divisor + (dividend % divisor != 0);
+}
+
+static inline size_t ComputeBlockLength(unsigned level, size_t scale, size_t signalLength)
+{
+    constexpr unsigned BASIS_LENGTH = (WAVELET_BASIS * 2) - 1;
+
+    const size_t numerator = signalLength + ((1 << level) - 1) * BASIS_LENGTH;
+    const size_t denominator = scale;
+    const size_t blockLength = CeiledDivision(numerator, denominator) + BASIS_LENGTH;
+
+    return blockLength;
+}
+
+// The function performs an 'intelligent' downsampling, where every second coefficient is
+// stored as a coefficient of 'new' sample, instead of just being discarded. This allows
+// the decomposition to retain more information about the signal.
+static inline void DownsampleByDissolving(CoefficientsPerLevel& coefficients, unsigned level, unsigned blockLength)
+{
+    const unsigned shift = (1 << level) >> 1;
+    for (unsigned i = 0; i < shift; i++)
+    {
+        coefficients[shift + i].resize(blockLength);
+        unsigned oldRowColumn = 0;
+        unsigned newRowColumn = 0;
+        for (unsigned j = 0; j < coefficients[i].size(); j++)
+        {
+            unsigned row = j % 2 ? shift + i : i;
+            unsigned column = j % 2 ? newRowColumn++ : oldRowColumn++;
+            coefficients[row][column] = coefficients[i][j];
+        }
+        coefficients[i].resize(oldRowColumn); // Used to fill moved entries with zeros.
+        coefficients[i].resize(blockLength);
+    }
+}
+
+// Applies the high and low pass filters on the current low-frequency
+// wavelet coefficients, at the level determined by the caller.
+// https://upload.wikimedia.org/wikipedia/commons/1/16/Wavelets_-_SWT_Filter_Bank.png
+// The figure above depicts the process, where h_j prepresents a high- and g_j a low-pass
+// filters, applied at level j.
+// All the low frequency coefficients are overridden on each call, while the high
+// frequnecy ones are just added.
+inline void WaveletDecomposerRef::ApplyFilters(WaveletCoefficients& coefficients,
+    CoefficientsPerLevel& lowFrequencyCoefficients, size_t scale, size_t blockLength, unsigned level) const
+{
+    coefficients.data[level].resize(scale); // Adjust number of coefficient lists for that certain level
+    for (unsigned i = 0; i < scale; i++)
+    {
+        lowFrequencyCoefficients[i].resize(blockLength); // Extend with zeros/shrink to match size
+        coefficients.data[level][i] = // Apply Daubechies4 decomposition high pass filter
+            m_Convolution.Convolve(precomputed::DecompositionHighPassFilter, lowFrequencyCoefficients[i]);
+        lowFrequencyCoefficients[i] = // Apply Daubechies4 decomposition low pass filter
+            m_Convolution.Convolve(precomputed::DecompositionLowPassFilter, lowFrequencyCoefficients[i]);
+    }
+}
+
+WaveletDecomposerRef::WaveletDecomposerRef() : m_Convolution()
+{
+};
+
+WaveletCoefficients WaveletDecomposerRef::Decompose(Signal&& signal) const
+{
+    const size_t signalLength = signal.size();
+
+    WaveletCoefficients coefficients;
+    CoefficientsPerLevel& lowFrequencyCoefficients = coefficients.data[WAVELET_LEVELS];
+
+    // The number of samples N used to generate N coefficient lists
+    // for the lowest frequency decomposition.
+    constexpr size_t LOW_FREQ_SAMPLES_NUM = 1 << (WAVELET_LEVELS - 1); // 2^(WL - 1)
+    lowFrequencyCoefficients.resize(LOW_FREQ_SAMPLES_NUM);
+    lowFrequencyCoefficients[0] = std::move(signal); // Initialize first line with signal
+
+    size_t scale = 1; // Initial wavelet scale (or it's frequency)
+    size_t blockLength = ComputeBlockLength(0, scale, signalLength); // Initial number of coefficients
+
+    for (unsigned currentLevel = 0; currentLevel < WAVELET_LEVELS - 1; currentLevel++)
+    {
+        ApplyFilters(coefficients, lowFrequencyCoefficients, scale, blockLength, currentLevel);
+
+        scale = ComputeScale(currentLevel);
+        blockLength = ComputeBlockLength(currentLevel + 1, scale, signalLength);
+        DownsampleByDissolving(lowFrequencyCoefficients, currentLevel + 1, (unsigned)blockLength);
+    }
+
+    ApplyFilters(coefficients, lowFrequencyCoefficients, scale, blockLength, WAVELET_LEVELS - 1);
+
+    return coefficients;
+}
+}

--- a/src/Spectre.libWavelet/WaveletDecomposerRef.h
+++ b/src/Spectre.libWavelet/WaveletDecomposerRef.h
@@ -22,38 +22,37 @@ limitations under the License.
 
 namespace spectre::algorithm::wavelet
 {
-    constexpr unsigned int WAVELET_LEVELS = 10;
-    constexpr unsigned int WAVELET_BASIS = 4;
+constexpr unsigned int WAVELET_LEVELS = 10;
+constexpr unsigned int WAVELET_BASIS = 4;
 
-    struct WaveletCoefficients
-    {
-        CoefficientsPerLevel data[WAVELET_LEVELS + 1]; // + 1 for lowest frequency
-    };
+struct WaveletCoefficients
+{
+    CoefficientsPerLevel data[WAVELET_LEVELS + 1]; // + 1 for lowest frequency
+};
 
+/// <summary>
+/// Decomposes the signal into set of Daubechies coefficients.
+/// </summary>
+class WaveletDecomposerRef
+{
+public:
     /// <summary>
-    /// Decomposes the signal into set of Daubechies coefficients.
+    /// Initializes a new instance of the <see cref="WaveletDecomposer"/> class.
     /// </summary>
-    class WaveletDecomposerRef
-    {
-    public:
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WaveletDecomposer"/> class.
-        /// </summary>
-        /// <param name="threshold">Treshold to be used.</param>
-        explicit WaveletDecomposerRef();
-        /// <summary>
-        /// Decomposes the signal into wavelet coefficients.
-        /// </summary>
-        /// <param name="signal">Signal to decompose.</param>
-        /// <returns>Set of Daubechies wavelet coefficients.</returns>
-        WaveletCoefficients Decompose(Signal&& signal) const;
+    explicit WaveletDecomposerRef();
+    /// <summary>
+    /// Decomposes the signal into wavelet coefficients.
+    /// </summary>
+    /// <param name="signal">Signal to decompose.</param>
+    /// <returns>Set of Daubechies wavelet coefficients.</returns>
+    WaveletCoefficients Decompose(Signal&& signal) const;
 
-    private:
-        inline void WaveletDecomposerRef::ApplyFilters(
-            WaveletCoefficients& coefficients,
-            CoefficientsPerLevel& lowFrequencyCoefficients,
-            size_t scale, size_t blockLength, unsigned level) const;
+private:
+    inline void WaveletDecomposerRef::ApplyFilters(
+        WaveletCoefficients& coefficients,
+        CoefficientsPerLevel& lowFrequencyCoefficients,
+        size_t scale, size_t blockLength, unsigned level) const;
 
-        const Convolution m_Convolution;
-    };
+    const Convolution m_Convolution;
+};
 }

--- a/src/Spectre.libWavelet/WaveletDecomposerRef.h
+++ b/src/Spectre.libWavelet/WaveletDecomposerRef.h
@@ -1,0 +1,59 @@
+/*
+* WaveletDecomposerRef.h
+* Reference implementation of wavelet decomposer.
+*
+Copyright 2018 Michal Gallus
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#pragma once
+#include "Convolution.h"
+#include "DataTypes.h"
+
+namespace spectre::algorithm::wavelet
+{
+    constexpr unsigned int WAVELET_LEVELS = 10;
+    constexpr unsigned int WAVELET_BASIS = 4;
+
+    struct WaveletCoefficients
+    {
+        CoefficientsPerLevel data[WAVELET_LEVELS + 1]; // + 1 for lowest frequency
+    };
+
+    /// <summary>
+    /// Decomposes the signal into set of Daubechies coefficients.
+    /// </summary>
+    class WaveletDecomposerRef
+    {
+    public:
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WaveletDecomposer"/> class.
+        /// </summary>
+        /// <param name="threshold">Treshold to be used.</param>
+        explicit WaveletDecomposerRef();
+        /// <summary>
+        /// Decomposes the signal into wavelet coefficients.
+        /// </summary>
+        /// <param name="signal">Signal to decompose.</param>
+        /// <returns>Set of Daubechies wavelet coefficients.</returns>
+        WaveletCoefficients Decompose(Signal&& signal) const;
+
+    private:
+        inline void WaveletDecomposerRef::ApplyFilters(
+            WaveletCoefficients& coefficients,
+            CoefficientsPerLevel& lowFrequencyCoefficients,
+            size_t scale, size_t blockLength, unsigned level) const;
+
+        const Convolution m_Convolution;
+    };
+}

--- a/src/native-algorithms.sln
+++ b/src/native-algorithms.sln
@@ -81,6 +81,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Spectre.libWavelet", "Spect
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Spectre.libWavelet.Tests", "Spectre.libWavelet.Tests\Spectre.libWavelet.Tests.vcxproj", "{5B426532-B8C6-43BD-807A-CF772C731DC1}"
 	ProjectSection(ProjectDependencies) = postProject
+		{7EB0161F-4E8A-4C72-BA18-31B554F411F2} = {7EB0161F-4E8A-4C72-BA18-31B554F411F2}
 		{3BD3D898-F14B-4129-BAE5-6E3E83E9D982} = {3BD3D898-F14B-4129-BAE5-6E3E83E9D982}
 	EndProjectSection
 EndProject


### PR DESCRIPTION
First and foremost, commits introduce the reference version of wavelet decomposer, backed up with numerous comments and references. Secondly, the convolution class is modified so that it can make use of the format of precomputed Daubechies 4 filters. Lastly, the filter coefficients themselves have got their names revised as well.