### PR TITLE
Soft tresholder for signal denoising

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
 configuration:
   - Debug
   - Release
-version: 3.12.0.{build}
+version: 3.13.0.{build}
 
 init:
 - cmd: echo Project - %APPVEYOR_PROJECT_NAME%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
 configuration:
   - Debug
   - Release
-version: 3.11.0.{build}
+version: 3.12.0.{build}
 
 init:
 - cmd: echo Project - %APPVEYOR_PROJECT_NAME%

--- a/src/Spectre.libStatistics.Tests/StatisticsTest.cpp
+++ b/src/Spectre.libStatistics.Tests/StatisticsTest.cpp
@@ -58,9 +58,9 @@ TEST(MedianTest, calculates_vector_median)
     EXPECT_THAT(Median(data), 2.);
 }
 
-TEST(MedianTest, throws_on_empty_vector)
+TEST(MedianTest, median_of_empty_is_zero)
 {
-    EXPECT_THROW(MedianAbsoluteDeviation(empty), spectre::core::exception::EmptyArgumentException);
+    EXPECT_THAT(Median(empty), 0.);
 }
 
 TEST(VarianceTest, calculates_unbiased_vector_variance_by_default)
@@ -110,8 +110,8 @@ TEST(MedianAbsoluteDeviationTest, calculates_median_absolute_deviation_of_vector
     EXPECT_THAT(MedianAbsoluteDeviation(data), DoubleEq(1.0));
 }
 
-TEST(MedianAbsoluteDeviationTest, throws_exception_when_set_is_empty)
+TEST(MedianAbsoluteDeviationTest, median_absolute_deviation_of_empty_is_zero)
 {
-    EXPECT_THROW(MedianAbsoluteDeviation(empty), spectre::core::exception::EmptyArgumentException);
+    EXPECT_THAT(MedianAbsoluteDeviation(empty), 0.);
 }
 }

--- a/src/Spectre.libStatistics.Tests/StatisticsTest.cpp
+++ b/src/Spectre.libStatistics.Tests/StatisticsTest.cpp
@@ -2,7 +2,7 @@
 * StatisticsTest.cpp
 * Tests basic vector statistics.
 *
-Copyright 2017 Grzegorz Mrukwa
+Copyright 2018 Grzegorz Mrukwa, Michal Gallus
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -53,6 +53,16 @@ TEST(MeanTest, mean_of_empty_is_zero)
     EXPECT_THAT(Mean(empty), 0.);
 }
 
+TEST(MedianTest, calculates_vector_median)
+{
+    EXPECT_THAT(Median(data), 2.);
+}
+
+TEST(MedianTest, throws_on_empty_vector)
+{
+    EXPECT_THROW(MedianAbsoluteDeviation(empty), spectre::core::exception::EmptyArgumentException);
+}
+
 TEST(VarianceTest, calculates_unbiased_vector_variance_by_default)
 {
     EXPECT_THAT(Variance(data), DoubleEq(1.0));
@@ -93,5 +103,15 @@ TEST(MeanAbsoluteDeviationTest, calculates_mean_absolute_deviation_of_vector)
 TEST(MeanAbsoluteDeviationTest, mean_absolute_deviation_of_empty_is_zero)
 {
     EXPECT_THAT(MeanAbsoluteDeviation(empty), 0.);
+}
+
+TEST(MedianAbsoluteDeviationTest, calculates_median_absolute_deviation_of_vector)
+{
+    EXPECT_THAT(MedianAbsoluteDeviation(data), DoubleEq(1.0));
+}
+
+TEST(MedianAbsoluteDeviationTest, throws_exception_when_set_is_empty)
+{
+    EXPECT_THROW(MedianAbsoluteDeviation(empty), spectre::core::exception::EmptyArgumentException);
 }
 }

--- a/src/Spectre.libStatistics/Statistics.h
+++ b/src/Spectre.libStatistics/Statistics.h
@@ -59,9 +59,9 @@ template <class DataType>
 DataType Median(gsl::span<const DataType> data)
 {
     static_assert(std::is_arithmetic_v<DataType>, "DataType: expected arithmetic.");
+    if (data.size() == 0) throw spectre::core::exception::EmptyArgumentException("Median: Provided vector is empty");
     std::vector<std::remove_const<DataType>::type> sortedData(data.begin(), data.end());
     std::sort(sortedData.begin(), sortedData.end());
-    if (data.size() == 0) throw spectre::core::exception::EmptyArgumentException("Median: Provided vector is empty");
     if (data.size() % 2) return sortedData[data.size() / 2];
     else return (sortedData[data.size() / 2] + sortedData[data.size() / 2 - 1]) / 2.0;
 }

--- a/src/Spectre.libStatistics/Statistics.h
+++ b/src/Spectre.libStatistics/Statistics.h
@@ -51,7 +51,7 @@ constexpr DataType Mean(gsl::span<const DataType> data)
 }
 
 /// <summary>
-/// Obtain median of the specified data.
+/// Obtain median of the specified data. Return 0 when the input data is empty.
 /// </summary>
 /// <param name="data">The data.</param>
 /// <returns>Median of the elements.</returns>
@@ -59,7 +59,7 @@ template <class DataType>
 DataType Median(gsl::span<const DataType> data)
 {
     static_assert(std::is_arithmetic_v<DataType>, "DataType: expected arithmetic.");
-    if (data.size() == 0) throw spectre::core::exception::EmptyArgumentException("Median: Provided vector is empty");
+    if (data.size() == 0) return static_cast<DataType>(0.0);
     std::vector<std::remove_const<DataType>::type> sortedData(data.begin(), data.end());
     std::sort(sortedData.begin(), sortedData.end());
     if (data.size() % 2) return sortedData[data.size() / 2];
@@ -115,7 +115,7 @@ DataType MeanAbsoluteDeviation(gsl::span<const DataType> data)
 }
 
 /// <summary>
-/// Find median absolute deviation of the data.
+/// Find median absolute deviation of the data. Return 0 when input data is empty.
 /// </summary>
 /// <param name="data">The data.</param>
 /// <returns>Median absolute deviation of the elements.</returns>

--- a/src/Spectre.libStatistics/Statistics.h
+++ b/src/Spectre.libStatistics/Statistics.h
@@ -2,7 +2,7 @@
 * Statistics.h
 * Statistics calculated on vectors.
 *
-Copyright 2017 Grzegorz Mrukwa
+Copyright 2017-2018 Grzegorz Mrukwa, Michal Gallus
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,7 +20,9 @@ limitations under the License.
 #pragma once
 #include <numeric>
 #include <span.h>
+#include "Spectre.libException/EmptyArgumentException.h"
 #include "Spectre.libStatistics/Math.h"
+
 
 namespace spectre::statistics::simple_statistics
 {
@@ -46,6 +48,22 @@ constexpr DataType Mean(gsl::span<const DataType> data)
 {
     static_assert(std::is_arithmetic_v<DataType>, "DataType: expected arithmetic.");
     return Sum(data) / (data.size() != 0 ? data.size() : 1);
+}
+
+/// <summary>
+/// Obtain median of the specified data.
+/// </summary>
+/// <param name="data">The data.</param>
+/// <returns>Median of the elements.</returns>
+template <class DataType>
+DataType Median(gsl::span<const DataType> data)
+{
+    static_assert(std::is_arithmetic_v<DataType>, "DataType: expected arithmetic.");
+    std::vector<std::remove_const<DataType>::type> sortedData(data.begin(), data.end());
+    std::sort(sortedData.begin(), sortedData.end());
+    if (data.size() == 0) throw spectre::core::exception::EmptyArgumentException("Median: Provided vector is empty");
+    if (data.size() % 2) return sortedData[data.size() / 2];
+    else return (sortedData[data.size() / 2] + sortedData[data.size() / 2 - 1]) / 2.0;
 }
 
 /// <summary>
@@ -85,7 +103,7 @@ DataType Variance(gsl::span<const DataType> first, gsl::span<const DataType> sec
 /// Find mean absolute deviation of the data.
 /// </summary>
 /// <param name="data">The data.</param>
-/// <returns>Mean absolute deviation of the elements</returns>
+/// <returns>Mean absolute deviation of the elements.</returns>
 template <class DataType>
 DataType MeanAbsoluteDeviation(gsl::span<const DataType> data)
 {
@@ -94,5 +112,21 @@ DataType MeanAbsoluteDeviation(gsl::span<const DataType> data)
     const auto deviation = basic_math::minus(data, mean);
     const auto absoluteDeviation = basic_math::abs(gsl::as_span(deviation));
     return Mean(gsl::as_span(absoluteDeviation));
+}
+
+/// <summary>
+/// Find median absolute deviation of the data.
+/// </summary>
+/// <param name="data">The data.</param>
+/// <returns>Median absolute deviation of the elements.</returns>
+template <class DataType>
+DataType MedianAbsoluteDeviation(gsl::span<DataType> data)
+{
+    static_assert(std::is_arithmetic_v<DataType>, "DataType: expected arithmetic.");
+    gsl::span<const DataType> constSpan(data);
+    const auto median = Median(constSpan);
+    const auto deviation = basic_math::minus(constSpan, median);
+    const auto absoluteDeviation = basic_math::abs(gsl::as_span(deviation));
+    return Median(gsl::as_span(absoluteDeviation));
 }
 }

--- a/src/Spectre.libWavelet.Tests/MedianAbsoluteDeviationNoiseEstimatorTest.cpp
+++ b/src/Spectre.libWavelet.Tests/MedianAbsoluteDeviationNoiseEstimatorTest.cpp
@@ -1,5 +1,5 @@
 /*
-* MeanAbsoluteDeviationNoiseEstimatorTest.cpp
+* MedianAbsoluteDeviationNoiseEstimatorTest.cpp
 * Tests Mean Absolute Deviation noise estimator.
 *
 Copyright 2018 Michal Gallus
@@ -18,29 +18,29 @@ limitations under the License.
 */
 
 #include <gtest/gtest.h>
-#include "Spectre.libWavelet\MeanAbsoluteDeviationNoiseEstimator.h"
+#include "Spectre.libWavelet\MedianAbsoluteDeviationNoiseEstimator.h"
 
 namespace
 {
     using namespace spectre::algorithm::wavelet;
 
-    TEST(MeanAbsoluteDeviationNoiseEstimatorInitialization, initializes)
+    TEST(MedianAbsoluteDeviationNoiseEstimatorInitialization, initializes)
     {
-        EXPECT_NO_THROW(MeanAbsoluteDeviationNoiseEstimator(5.0));
-        EXPECT_NO_THROW(MeanAbsoluteDeviationNoiseEstimator());
+        EXPECT_NO_THROW(MedianAbsoluteDeviationNoiseEstimator(5.0));
+        EXPECT_NO_THROW(MedianAbsoluteDeviationNoiseEstimator());
     }
 
-    class MeanAbsoluteDeviationNoiseEstimatorTest : public ::testing::Test
+    class MedianAbsoluteDeviationNoiseEstimatorTest : public ::testing::Test
     {
     protected:
-        MeanAbsoluteDeviationNoiseEstimator estimator;
+        MedianAbsoluteDeviationNoiseEstimator estimator;
     };
 
-    TEST_F(MeanAbsoluteDeviationNoiseEstimatorTest, estimates_noise_for_regular_input)
+    TEST_F(MedianAbsoluteDeviationNoiseEstimatorTest, estimates_noise_for_regular_input)
     {
         Signal signal = { 1.0f, 2.0f, 3.0f };
         DataType maxAbsoluteError = 0.0001;
-        constexpr DataType result = static_cast<DataType>(1.4650890114825907);
+        constexpr DataType result = static_cast<DataType>(2.1976335172238861);
 
         DataType estimate = estimator.Estimate(signal);
         ASSERT_NEAR(estimate, result, maxAbsoluteError);

--- a/src/Spectre.libWavelet.Tests/SoftThresholderTest.cpp
+++ b/src/Spectre.libWavelet.Tests/SoftThresholderTest.cpp
@@ -18,7 +18,11 @@ limitations under the License.
 */
 
 #include <gtest/gtest.h>
+#include "FloatingPointVectorMatcher.h"
+#include "Spectre.libFunctional\Range.h"
 #include "Spectre.libWavelet\SoftThresholder.h"
+#include "Spectre.libWavelet\WaveletDecomposerRef.h"
+#include "Spectre.libWavelet\MedianAbsoluteDeviationNoiseEstimator.h"
 
 namespace
 {
@@ -34,16 +38,138 @@ namespace
     class SoftThresholderTest : public ::testing::Test
     {
     public:
-        SoftThresholderTest() : tresholder(1.0) {}
+        SoftThresholderTest()
+        {
+            firstHighFrequencyResult = {
+                0,
+                -0.127493589089253,
+                0.151206719715479,
+                0.00479470902963920,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                2.20089390886932,
+                -4.51142553491165,
+                1.10714493870363,
+                1.53339464355807,
+                0,
+                -0.277842095062875,
+                0
+            };
+            firstRowLastHighFrequencyResult = {
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                -0.459393424585978,
+                1.36777227988842,
+                -1.14551029281067,
+                0,
+                0.267529587033900,
+                0,
+                0,
+                0,
+                0
+            };
+            lastRowLastHighFrequencyResult = {
+                0,
+                0,
+                0,
+                0,
+                0,
+                -0.470784267254399,
+                1.37846580462384,
+                -1.14836949301628,
+                0,
+                0.268272856432259,
+                0,
+                0,
+                0,
+                0,
+                0
+            };
+            firstLowFrequencyResult = {
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                -0.237055466453466,
+                0,
+                1.13010903257345,
+                1.31414453610110,
+                0.359082154861514,
+                0,
+            };
+            lastLowFrequencyResult = {
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                -0.235667100831742,
+                0,
+                1.12788050173993,
+                1.31646362434624,
+                0.360650780643517,
+                0,
+                0,
+            };
+        }
     protected:
-        SoftThresholder tresholder;
+        WaveletDecomposerRef decomposer;
+        std::vector<DataType> lastRowLastHighFrequencyResult;
+        std::vector<DataType> firstRowLastHighFrequencyResult;
+        std::vector<DataType> firstHighFrequencyResult;
+        std::vector<DataType> firstLowFrequencyResult;
+        std::vector<DataType> lastLowFrequencyResult;
     };
 
-    TEST_F(SoftThresholderTest, properly_tresholds_signal)
+    TEST_F(SoftThresholderTest, properly_tresholds_coefficients)
     {
-        Signal input = { -1.0f, 2.0f, -3.0f, 4.0f };
-        Signal output = tresholder(input);
-        Signal correctOutput = { -0.0f, 1.0f, -2.0f, 3.0f };
-        ASSERT_EQ(correctOutput, output);
+        constexpr unsigned signalLength = 10;
+        Signal signal = spectre::core::functional::range<DataType>(signalLength);
+
+        // Decompose signal
+        WaveletCoefficients coefficients = decomposer.Decompose(std::move(signal));
+
+        // Extract coefficients necessary for noise estimator
+        Signal highFreqCoefficients(signalLength);
+        highFreqCoefficients.assign(coefficients.data[0][0].begin(),
+            coefficients.data[0][0].begin() + signalLength);
+
+        // Estimate tresholder's treshold value based on extracted coefficients
+        MedianAbsoluteDeviationNoiseEstimator noiseEstimator;
+        DataType treshold = noiseEstimator.Estimate(highFreqCoefficients);
+        SoftThresholder tresholder(treshold);
+
+        // Appply Soft-tresholding
+        WaveletCoefficients output = tresholder(std::move(coefficients));
+        WaveletCoefficients correctOutput;
+
+        // Check if the coefficients have appropriate values
+        auto doubleNear = double_near(0.001);
+        EXPECT_THAT(coefficients.data[0][0],
+            testing::Pointwise(doubleNear, firstHighFrequencyResult));
+        EXPECT_THAT(coefficients.data[WAVELET_LEVELS - 1][0],
+            testing::Pointwise(doubleNear, firstRowLastHighFrequencyResult));
+        EXPECT_THAT(coefficients.data[WAVELET_LEVELS - 1][(1 << (WAVELET_LEVELS - 1)) - 1],
+            testing::Pointwise(doubleNear, lastRowLastHighFrequencyResult));
+        EXPECT_THAT(coefficients.data[WAVELET_LEVELS][0],
+            testing::Pointwise(doubleNear, firstLowFrequencyResult));
+        EXPECT_THAT(coefficients.data[WAVELET_LEVELS][(1 << (WAVELET_LEVELS - 1)) - 1],
+            testing::Pointwise(doubleNear, lastLowFrequencyResult));
     }
 }

--- a/src/Spectre.libWavelet.Tests/Spectre.libWavelet.Tests.vcxproj
+++ b/src/Spectre.libWavelet.Tests/Spectre.libWavelet.Tests.vcxproj
@@ -138,7 +138,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\Common\Main.cpp" />
-    <ClCompile Include="MeanAbsoluteDeviationNoiseEstimatorTest.cpp" />
+    <ClCompile Include="MedianAbsoluteDeviationNoiseEstimatorTest.cpp" />
     <ClCompile Include="ConvolutionTest.cpp" />
     <ClCompile Include="SoftThresholderTest.cpp" />
     <ClCompile Include="WaveletDecomposerRefTest.cpp" />

--- a/src/Spectre.libWavelet.Tests/Spectre.libWavelet.Tests.vcxproj.filters
+++ b/src/Spectre.libWavelet.Tests/Spectre.libWavelet.Tests.vcxproj.filters
@@ -24,9 +24,6 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="MeanAbsoluteDeviationNoiseEstimatorTest.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="SoftThresholderTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -37,6 +34,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="WaveletReconstructorRefTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="MedianAbsoluteDeviationNoiseEstimatorTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/Spectre.libWavelet/MedianAbsoluteDeviationNoiseEstimator.cpp
+++ b/src/Spectre.libWavelet/MedianAbsoluteDeviationNoiseEstimator.cpp
@@ -1,6 +1,6 @@
 /*
- * MeanAbsoluteDeviationNoiseEstimator.cpp
- * Estimates mean absolute devation of noise in the signal.
+ * MedianAbsoluteDeviationNoiseEstimator.cpp
+ * Estimates median absolute devation of noise in the signal.
  *
    Copyright 2018 Michal Gallus
 
@@ -17,21 +17,21 @@
    limitations under the License.
 */
 #include "Spectre.libStatistics/Statistics.h"
-#include "MeanAbsoluteDeviationNoiseEstimator.h"
+#include "MedianAbsoluteDeviationNoiseEstimator.h"
 
 namespace spectre::algorithm::wavelet
 {
-MeanAbsoluteDeviationNoiseEstimator::MeanAbsoluteDeviationNoiseEstimator(DataType multiplier) :
+    MedianAbsoluteDeviationNoiseEstimator::MedianAbsoluteDeviationNoiseEstimator(DataType multiplier) :
     m_Multiplier(multiplier)
 {
 }
 
-DataType MeanAbsoluteDeviationNoiseEstimator::Estimate(const Signal& intensities) const
+DataType MedianAbsoluteDeviationNoiseEstimator::Estimate(Signal& highFreqCoefficients) const
 {
-    constexpr auto locationOfThirdQuartileInNormalDistribution = static_cast<DataType>(.6745);
+    constexpr auto inverseOfThirdQuartileInNormalDistribution = static_cast<DataType>(1.0 / .6745);
     return m_Multiplier
-        * sqrt(2 * log(intensities.size()))
-        * statistics::simple_statistics::MeanAbsoluteDeviation(gsl::as_span(intensities))
-        / locationOfThirdQuartileInNormalDistribution;
+        * sqrt(2 * log(highFreqCoefficients.size()))
+        * statistics::simple_statistics::MedianAbsoluteDeviation(gsl::as_span(highFreqCoefficients))
+        * inverseOfThirdQuartileInNormalDistribution;
 }
 }

--- a/src/Spectre.libWavelet/MedianAbsoluteDeviationNoiseEstimator.h
+++ b/src/Spectre.libWavelet/MedianAbsoluteDeviationNoiseEstimator.h
@@ -1,6 +1,6 @@
 /*
- * MeanAbsoluteDeviationNoiseEstimator.h
- * Estimates mean absolute devation of noise in the signal.
+ * MedianAbsoluteDeviationNoiseEstimator.h
+ * Estimates median absolute devation of noise in the signal.
  *
    Copyright 2018 Michal Gallus
 
@@ -24,21 +24,21 @@ namespace spectre::algorithm::wavelet
 /// <summary>
 /// Estimates the Mean-absolute devaition of the noise in the signal
 /// </summary>
-class MeanAbsoluteDeviationNoiseEstimator
+class MedianAbsoluteDeviationNoiseEstimator
 {
 public:
     /// <summary>
     /// Initializes a new instance of the
-    /// <see cref="MeanAbsoluteDeviationNoiseEstimator"/> class.
+    /// <see cref="MedianAbsoluteDeviationNoiseEstimator"/> class.
     /// </summary>
     /// <param name="multiplier">The multiplier used for computations.</param>
-    explicit MeanAbsoluteDeviationNoiseEstimator(DataType multiplier=1.0);
+    explicit MedianAbsoluteDeviationNoiseEstimator(DataType multiplier=1.0);
     /// <summary>
     /// Estimates the MAD of the noise.
     /// </summary>
     /// <param name="intensities">Signal to be analyzed.</param>
     /// <returns>Estiamte of the noise in the signal.</returns>
-    DataType Estimate(const Signal& intensities) const;
+    DataType Estimate(Signal& intensities) const;
 private:
     const DataType m_Multiplier;
 };

--- a/src/Spectre.libWavelet/SoftThresholder.h
+++ b/src/Spectre.libWavelet/SoftThresholder.h
@@ -17,7 +17,7 @@
    limitations under the License.
 */
 #pragma once
-#include "DataTypes.h"
+#include "WaveletCoefficients.h"
 
 namespace spectre::algorithm::wavelet
 {
@@ -33,11 +33,11 @@ public:
     /// <param name="threshold">Treshold to be used.</param>
     explicit SoftThresholder(DataType threshold);
     /// <summary>
-    /// Tresholds the signal
+    /// Tresholds the coefficients
     /// </summary>
-    /// <param name="signal">Signal to apply tresholding to.</param>
+    /// <param name="coefficients">Signal to apply tresholding to.</param>
     /// <returns>Tresholded signal.</returns>
-    Signal operator()(const Signal& signal) const;
+    WaveletCoefficients operator()(WaveletCoefficients&& coefficients) const;
 private:
     const DataType m_Threshold;
 };

--- a/src/Spectre.libWavelet/Spectre.libWavelet.vcxproj
+++ b/src/Spectre.libWavelet/Spectre.libWavelet.vcxproj
@@ -129,7 +129,7 @@
     <ClInclude Include="AlgorithmConstants.h" />
     <ClInclude Include="Convolution.h" />
     <ClInclude Include="DataTypes.h" />
-    <ClInclude Include="MeanAbsoluteDeviationNoiseEstimator.h" />
+    <ClInclude Include="MedianAbsoluteDeviationNoiseEstimator.h" />
     <ClInclude Include="PrecomputedDaubechiesCoefficients.h" />
     <ClInclude Include="SoftThresholder.h" />
     <ClInclude Include="WaveletCoefficients.h" />
@@ -139,7 +139,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Convolution.cpp" />
-    <ClCompile Include="MeanAbsoluteDeviationNoiseEstimator.cpp" />
+    <ClCompile Include="MedianAbsoluteDeviationNoiseEstimator.cpp" />
     <ClCompile Include="SoftThresholder.cpp" />
     <ClCompile Include="WaveletDecomposerRef.cpp" />
     <ClCompile Include="WaveletReconstructorRef.cpp" />

--- a/src/Spectre.libWavelet/Spectre.libWavelet.vcxproj.filters
+++ b/src/Spectre.libWavelet/Spectre.libWavelet.vcxproj.filters
@@ -15,9 +15,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="MeanAbsoluteDeviationNoiseEstimator.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="DataTypes.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -45,11 +42,11 @@
     <ClInclude Include="WaveletUtils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="MedianAbsoluteDeviationNoiseEstimator.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="MeanAbsoluteDeviationNoiseEstimator.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="SoftThresholder.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -60,6 +57,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="WaveletReconstructorRef.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="Convolution.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="MedianAbsoluteDeviationNoiseEstimator.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/Spectre.libWavelet/WaveletCoefficients.h
+++ b/src/Spectre.libWavelet/WaveletCoefficients.h
@@ -1,5 +1,6 @@
 /*
 * WaveletCoefficients.h
+* Decouple wavelet coefficients & constants from decomposer
 * Coefficients used by wavelet decomposition and reconstruction.
 *
 Copyright 2018 Michal Gallus

--- a/src/Spectre.libWavelet/WaveletCoefficients.h
+++ b/src/Spectre.libWavelet/WaveletCoefficients.h
@@ -1,6 +1,5 @@
 /*
 * WaveletCoefficients.h
-* Decouple wavelet coefficients & constants from decomposer
 * Coefficients used by wavelet decomposition and reconstruction.
 *
 Copyright 2018 Michal Gallus


### PR DESCRIPTION
Soft tresholder filters out the coefficients of decomposed signal.

The MeanAbsoluteDeviationNoiseEstimator has been revamped to Median(...) to comply with original version. 