### PR TITLE
Add recognition of test code for BCH

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,3 +1,11 @@
 component_depth: 2
 languages:
-- cpp
+- name: cpp
+  production:
+    exclude:
+      - /src/.*\.Tests/.*\.h
+      - /src/.*\.Tests/.*\.cpp
+  test:
+    include:
+      - /src/.*\.Tests/.*\.h
+      - /src/.*\.Tests/.*\.cpp


### PR DESCRIPTION
Better Code Hub had problem and qualified all of the files as production code. This should separate them.

One of the guidelines seems "lost" to BCH, since proportions in the code changed. Other two are now passed, while they weren't before.

I hope this will give us better insight into potential problems with the code. Right now it's pretty good I'd say :)