### PR TITLE
Splitting peaks finder 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
 configuration:
   - Debug
   - Release
-version: 4.1.0.{build}
+version: 4.2.0.{build}
 
 init:
 - cmd: echo Project - %APPVEYOR_PROJECT_NAME%

--- a/src/Spectre.libGaussianMixtureModelling.Tests/ClearPeakFinderTest.cpp
+++ b/src/Spectre.libGaussianMixtureModelling.Tests/ClearPeakFinderTest.cpp
@@ -1,0 +1,89 @@
+/*
+* ClearPeakFinderTest.cpp
+* Tests finding of splitting peaks among the list of peaks.
+*
+Copyright 2018 Michal Gallus
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#define GTEST_LANG_CXX11 1
+
+#include <gtest/gtest.h>
+#include "ClearPeakFinder.h"
+
+namespace spectre::unsupervised::gmm
+{
+    class ClearPeakFinderTest : public ::testing::Test
+    {
+    public:
+        ClearPeakFinderTest()
+        {
+            peaks.mzs = {
+                2.0184, 2.0448, 2.0712, 2.0848, 2.0920,
+                2.1096, 2.1344, 2.1728, 2.1872, 2.1952,
+                2.2200, 2.2416, 2.2576, 2.3000, 2.3368,
+                2.3712, 2.4160, 2.4400, 2.5009, 2.5257
+            };
+            peaks.intensities = {
+                0.0006, 0.0003, 0.0122, 0.0003, 0.0004,
+                0.0006, 0.0007, 0.0092, 0.0005, 0.0004,
+                0.0223, 0.0005, 0.0005, 0.1317, 0.0003,
+                0.0765, 0.0258, 0.1851, 0.0322, 0.0439
+            };
+            peakQualities = {
+                00.4503, 0.2564, 10.7977, 000.2979, 00.3453,
+                00.5217, 0.6438, 08.5515, 000.4669, 00.3708,
+                21.8366, 0.4437, 00.5053, 127.7454, 00.3045,
+                72.3374, 5.2706, 37.8574, 010.9249, 14.8931
+            };
+        }
+    protected:
+        ClearPeakFinder finder;
+        Data peakQualities;
+        Peaks peaks;
+    };
+
+    TEST_F(ClearPeakFinderTest, correctly_finds_clear_peaks)
+    {
+        GmmOptions options;
+        DataType resolutionCoeff = 0.0027;
+        Indices indices = finder.FindClearPeaks(peaks, peakQualities, options, resolutionCoeff);
+        Indices correct = { 7, 13 };
+        ASSERT_EQ(correct, indices);
+    }
+
+    TEST_F(ClearPeakFinderTest, throws_on_empty_peak_list)
+    {
+        GmmOptions options;
+        DataType resolutionCoeff = 0.0027;
+        EXPECT_THROW(finder.FindClearPeaks({}, peakQualities, options, resolutionCoeff), std::invalid_argument);
+    }
+
+    TEST_F(ClearPeakFinderTest, throws_on_empty_quality_peak_list)
+    {
+        GmmOptions options;
+        DataType resolutionCoeff = 0.0027;
+        EXPECT_THROW(finder.FindClearPeaks(peaks, {}, options, resolutionCoeff), std::invalid_argument);
+    }
+
+    TEST_F(ClearPeakFinderTest, returns_empty_list_when_there_are_no_peaks)
+    {
+        GmmOptions options;
+        DataType resolutionCoeff = 0.0027;
+        Peaks peaks2;
+        peaks2.mzs = Data(50);
+        peaks2.intensities = Data(50); // All filled with zeros = no peaks.
+        Data qualities = Data(50);
+        auto test = finder.FindClearPeaks(peaks2, qualities, options, resolutionCoeff);
+    }
+}

--- a/src/Spectre.libGaussianMixtureModelling.Tests/ClearPeakFinderTest.cpp
+++ b/src/Spectre.libGaussianMixtureModelling.Tests/ClearPeakFinderTest.cpp
@@ -20,70 +20,81 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 #include "ClearPeakFinder.h"
+#include "Spectre.libException\EmptyArgumentException.h"
+#include "Spectre.libException\InconsistentArgumentSizesException.h"
 
 namespace spectre::unsupervised::gmm
 {
-    class ClearPeakFinderTest : public ::testing::Test
+using namespace core::exception;
+class ClearPeakFinderTest : public ::testing::Test
+{
+public:
+    ClearPeakFinderTest()
     {
-    public:
-        ClearPeakFinderTest()
-        {
-            peaks.mzs = {
-                2.0184, 2.0448, 2.0712, 2.0848, 2.0920,
-                2.1096, 2.1344, 2.1728, 2.1872, 2.1952,
-                2.2200, 2.2416, 2.2576, 2.3000, 2.3368,
-                2.3712, 2.4160, 2.4400, 2.5009, 2.5257
-            };
-            peaks.intensities = {
-                0.0006, 0.0003, 0.0122, 0.0003, 0.0004,
-                0.0006, 0.0007, 0.0092, 0.0005, 0.0004,
-                0.0223, 0.0005, 0.0005, 0.1317, 0.0003,
-                0.0765, 0.0258, 0.1851, 0.0322, 0.0439
-            };
-            peakQualities = {
-                00.4503, 0.2564, 10.7977, 000.2979, 00.3453,
-                00.5217, 0.6438, 08.5515, 000.4669, 00.3708,
-                21.8366, 0.4437, 00.5053, 127.7454, 00.3045,
-                72.3374, 5.2706, 37.8574, 010.9249, 14.8931
-            };
-        }
-    protected:
-        ClearPeakFinder finder;
-        Data peakQualities;
-        Peaks peaks;
-    };
-
-    TEST_F(ClearPeakFinderTest, correctly_finds_clear_peaks)
-    {
-        GmmOptions options;
-        DataType resolutionCoeff = 0.0027;
-        Indices indices = finder.FindClearPeaks(peaks, peakQualities, options, resolutionCoeff);
-        Indices correct = { 7, 13 };
-        ASSERT_EQ(correct, indices);
+        peaks.mzs = {
+            2.0184, 2.0448, 2.0712, 2.0848, 2.0920,
+            2.1096, 2.1344, 2.1728, 2.1872, 2.1952,
+            2.2200, 2.2416, 2.2576, 2.3000, 2.3368,
+            2.3712, 2.4160, 2.4400, 2.5009, 2.5257
+        };
+        peaks.intensities = {
+            0.0006, 0.0003, 0.0122, 0.0003, 0.0004,
+            0.0006, 0.0007, 0.0092, 0.0005, 0.0004,
+            0.0223, 0.0005, 0.0005, 0.1317, 0.0003,
+            0.0765, 0.0258, 0.1851, 0.0322, 0.0439
+        };
+        peakQualities = {
+            00.4503, 0.2564, 10.7977, 000.2979, 00.3453,
+            00.5217, 0.6438, 08.5515, 000.4669, 00.3708,
+            21.8366, 0.4437, 00.5053, 127.7454, 00.3045,
+            72.3374, 5.2706, 37.8574, 010.9249, 14.8931
+        };
     }
+protected:
+    ClearPeakFinder finder;
+    Data peakQualities;
+    Peaks peaks;
+};
 
-    TEST_F(ClearPeakFinderTest, throws_on_empty_peak_list)
-    {
-        GmmOptions options;
-        DataType resolutionCoeff = 0.0027;
-        EXPECT_THROW(finder.FindClearPeaks({}, peakQualities, options, resolutionCoeff), std::invalid_argument);
-    }
+TEST_F(ClearPeakFinderTest, correctly_finds_clear_peaks)
+{
+    GmmOptions options;
+    DataType resolutionCoeff = 0.0027;
+    Indices indices = finder.FindClearPeaks(peaks, peakQualities, options, resolutionCoeff);
+    Indices correct = { 7, 13 };
+    ASSERT_EQ(correct, indices);
+}
 
-    TEST_F(ClearPeakFinderTest, throws_on_empty_quality_peak_list)
-    {
-        GmmOptions options;
-        DataType resolutionCoeff = 0.0027;
-        EXPECT_THROW(finder.FindClearPeaks(peaks, {}, options, resolutionCoeff), std::invalid_argument);
-    }
+TEST_F(ClearPeakFinderTest, throws_on_empty_peak_list)
+{
+    GmmOptions options;
+    DataType resolutionCoeff = 0.0027;
+    EXPECT_THROW(finder.FindClearPeaks({}, peakQualities, options, resolutionCoeff), EmptyArgumentException);
+}
 
-    TEST_F(ClearPeakFinderTest, returns_empty_list_when_there_are_no_peaks)
-    {
-        GmmOptions options;
-        DataType resolutionCoeff = 0.0027;
-        Peaks peaks2;
-        peaks2.mzs = Data(50);
-        peaks2.intensities = Data(50); // All filled with zeros = no peaks.
-        Data qualities = Data(50);
-        auto test = finder.FindClearPeaks(peaks2, qualities, options, resolutionCoeff);
-    }
+TEST_F(ClearPeakFinderTest, throws_on_empty_quality_peak_list)
+{
+    GmmOptions options;
+    DataType resolutionCoeff = 0.0027;
+    EXPECT_THROW(finder.FindClearPeaks(peaks, {}, options, resolutionCoeff), EmptyArgumentException);
+}
+
+TEST_F(ClearPeakFinderTest, throws_on_different_peak_and_quality_list_sizes)
+{
+    GmmOptions options;
+    DataType resolutionCoeff = 0.0027;
+    Data qualities = { 0.0 };
+    EXPECT_THROW(finder.FindClearPeaks(peaks, qualities, options, resolutionCoeff), InconsistentArgumentSizesException);
+}
+
+TEST_F(ClearPeakFinderTest, returns_empty_list_when_there_are_no_peaks)
+{
+    GmmOptions options;
+    DataType resolutionCoeff = 0.0027;
+    Peaks peaks2;
+    peaks2.mzs = Data(50);
+    peaks2.intensities = Data(50); // All filled with zeros = no peaks.
+    Data qualities = Data(50);
+    auto test = finder.FindClearPeaks(peaks2, qualities, options, resolutionCoeff);
+}
 }

--- a/src/Spectre.libGaussianMixtureModelling.Tests/Spectre.libGaussianMixtureModelling.Tests.vcxproj
+++ b/src/Spectre.libGaussianMixtureModelling.Tests/Spectre.libGaussianMixtureModelling.Tests.vcxproj
@@ -99,7 +99,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>Spectre.libException.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Spectre.libGaussianMixtureModelling.lib;Spectre.libException.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -116,7 +116,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>Spectre.libException.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Spectre.libGaussianMixtureModelling.lib;Spectre.libException.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -137,7 +137,7 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>Spectre.libException.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Spectre.libGaussianMixtureModelling.lib;Spectre.libException.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -158,12 +158,13 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>Spectre.libException.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Spectre.libGaussianMixtureModelling.lib;Spectre.libException.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\Common\Main.cpp" />
+    <ClCompile Include="ClearPeakFinderTest.cpp" />
     <ClCompile Include="ExpectationMaximizationTest.cpp" />
     <ClCompile Include="GaussianMixtureModelTest.cpp" />
   </ItemGroup>

--- a/src/Spectre.libGaussianMixtureModelling.Tests/Spectre.libGaussianMixtureModelling.Tests.vcxproj.filters
+++ b/src/Spectre.libGaussianMixtureModelling.Tests/Spectre.libGaussianMixtureModelling.Tests.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ClearPeakFinderTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Spectre.libGaussianMixtureModelling/ClearPeakFinder.cpp
+++ b/src/Spectre.libGaussianMixtureModelling/ClearPeakFinder.cpp
@@ -18,9 +18,11 @@ limitations under the License.
 */
 #include <stdexcept>
 #include "ClearPeakFinder.h"
+#include "Spectre.libException\EmptyArgumentException.h"
 #include "Spectre.libFunctional\Filter.h"
 
 using namespace spectre::core::functional;
+using namespace spectre::core::exception;
 namespace spectre::unsupervised::gmm
 {
 // Find beginning/end of interval where the clear peaks are searched for.
@@ -62,8 +64,10 @@ static inline Index FindClearestPeak(unsigned currentOffset, unsigned intervalEn
 Indices ClearPeakFinder::FindClearPeaks(const Peaks& peaks, const DataView& peakQualities,
     const GmmOptions& options, DataType resolutionCoeff) const
 {
-    if (peaks.intensities.empty()) throw std::invalid_argument("Empty peak list");
-    if (peakQualities.empty()) throw std::invalid_argument("Empty peak quality list");
+    if (peaks.intensities.empty()) throw EmptyArgumentException("Empty peak list");
+    if (peakQualities.empty()) throw EmptyArgumentException("Empty peak quality list");
+    if (peaks.mzs.size() != (size_t)peakQualities.size()) throw InconsistentArgumentSizesException
+        ("peaks", peaks.mzs.size(), "peakQualities", peakQualities.size());
     const DataView& mzs = peaks.mzs;
     const DataView& intensities = peaks.intensities;
     const DataType  MAX_HEIGHT = *std::max_element(intensities.begin(), intensities.end());

--- a/src/Spectre.libGaussianMixtureModelling/ClearPeakFinder.cpp
+++ b/src/Spectre.libGaussianMixtureModelling/ClearPeakFinder.cpp
@@ -1,0 +1,102 @@
+/*
+* ClearPeakFinder.cpp
+* Finds indices of splitting peaks from among given peaks.
+*
+Copyright 2018 Michal Gallus
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include <stdexcept>
+#include "ClearPeakFinder.h"
+#include "Spectre.libFunctional\Filter.h"
+
+using namespace spectre::core::functional;
+namespace spectre::unsupervised::gmm
+{
+// Find beginning/end of interval where the clear peaks are searched for.
+static unsigned FindOffset(unsigned initialStep, unsigned minOffset,
+    const DataView& peakMzsView, DataType variationCoeffEstimate)
+{
+    DataType minMzRange = minOffset * variationCoeffEstimate * peakMzsView[initialStep];
+    for (unsigned i = minOffset; initialStep + i < (unsigned)peakMzsView.size(); i++)
+    {
+        DataType mzRange = peakMzsView[initialStep + i] - peakMzsView[initialStep];
+        if (mzRange > minMzRange) // It doesn't make sense to me either.
+        {                         // I just hope the BTB is smart enough
+            return i;             // to know its always (afaik) true.
+        }
+    }
+    return 0;
+}
+
+// Returns an index of the highest clear peak from the interval, or 0xDEADCELL if n/a.
+static inline Index FindClearestPeak(unsigned currentOffset, unsigned intervalEnd,
+    const DataView& intensities, const DataView& peakQualities,
+    DataType HEIGHT_THRESHOLD, DataType QUALITY_THRESHOLD)
+{
+    DataType maxIntensity = -1.0; // intensities asssmued to be non-negative
+    Index bestCandidate = 0xDEADCELL;
+    for (unsigned i = currentOffset; i < intervalEnd; i++)
+    {
+        if (  intensities[i] > HEIGHT_THRESHOLD  &&
+            peakQualities[i] > QUALITY_THRESHOLD &&
+              intensities[i] > maxIntensity)
+        {
+            bestCandidate = i;
+            maxIntensity = intensities[i];
+        }
+    }
+    return bestCandidate;
+}
+
+Indices ClearPeakFinder::FindClearPeaks(const Peaks& peaks, const DataView& peakQualities,
+    const GmmOptions& options, DataType resolutionCoeff) const
+{
+    if (peaks.intensities.empty()) throw std::invalid_argument("Empty peak list");
+    if (peakQualities.empty()) throw std::invalid_argument("Empty peak quality list");
+    const DataView& mzs = peaks.mzs;
+    const DataView& intensities = peaks.intensities;
+    const DataType  MAX_HEIGHT = *std::max_element(intensities.begin(), intensities.end());
+    const DataType  DETECTION_SENSITIVITY = options.sensitivity;
+    const DataType  HEIGHT_THRESHOLD = DETECTION_SENSITIVITY * MAX_HEIGHT;
+    const DataType  QUALITY_THRESHOLD = options.qualityThreshold;
+    const unsigned  PEAK_LOOKUP_RANGE = options.peakLookupRange;
+    const unsigned  JUMP = options.minJump;
+    const unsigned  INITIAL_JUMP = options.initialJump;
+
+    Indices clearPeaksIndices;
+    clearPeaksIndices.reserve(mzs.size() / PEAK_LOOKUP_RANGE); // Worst case scenario
+    unsigned currentOffset = FindOffset(0, INITIAL_JUMP - 1, mzs, resolutionCoeff);
+    unsigned newOffset = FindOffset(currentOffset, PEAK_LOOKUP_RANGE, mzs, resolutionCoeff);
+    unsigned jumpLength = 0;
+
+    while (newOffset) // != 0
+    {
+        unsigned intervalEnd = currentOffset + newOffset;
+        Index clearPeakIndex = FindClearestPeak(currentOffset, intervalEnd, intensities,
+            peakQualities, HEIGHT_THRESHOLD, QUALITY_THRESHOLD);
+        if (clearPeakIndex != 0xDEADCELL) // Peak found
+        {
+            clearPeaksIndices.push_back(clearPeakIndex);
+            jumpLength = JUMP;
+        }
+        else
+        {
+            jumpLength = 1;
+        }
+        currentOffset = intervalEnd + FindOffset(intervalEnd, jumpLength, mzs, resolutionCoeff);
+        newOffset = FindOffset(currentOffset, PEAK_LOOKUP_RANGE, mzs, resolutionCoeff);
+    }
+    return clearPeaksIndices;
+}
+}

--- a/src/Spectre.libGaussianMixtureModelling/ClearPeakFinder.h
+++ b/src/Spectre.libGaussianMixtureModelling/ClearPeakFinder.h
@@ -1,0 +1,44 @@
+/*
+* ClearPeakFinder.h
+* Finds indices of splitting peaks from among given peaks.
+*
+Copyright 2018 Michal Gallus
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+#include "DataTypes.h"
+#include "GmmOptions.h"
+#include <vector>
+
+namespace spectre::unsupervised::gmm
+{
+/// <summary>
+/// Finds indices of splitting peaks from among given peaks.
+/// </summary>
+class ClearPeakFinder
+{
+public:
+    /// <summary>
+    /// Finds splitting peaks in the signal.
+    /// </summary>
+    /// <param name="peakIndices">Signal in which minima shall be found.</param> // TODO Adjust this
+    /// <param name="mzs">M/zs of the signal.</param>
+    /// <param name="intensities">Intensities of the signal.</param>
+    /// <param name="peakQualities">Peak qualities.</param>
+    /// <returns>Indices of clear peaks in the signal.</returns>
+    Indices FindClearPeaks(const Peaks& peaks, const DataView& peakQualities,
+        const GmmOptions& options, DataType resolutionCoeff) const;
+};
+}

--- a/src/Spectre.libGaussianMixtureModelling/GmmOptions.h
+++ b/src/Spectre.libGaussianMixtureModelling/GmmOptions.h
@@ -1,0 +1,122 @@
+/*
+ * GmmOptions.h
+ * Tunable options for Gaussian Mixture Modelling algorithm.
+ *
+ Copyright 2018 Michal Gallus
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+#pragma once
+#include "DataTypes.h"
+
+namespace spectre::unsupervised::gmm
+{
+///<summary>
+/// Constitutes a set of default, modifyiable options for running Gaussian
+/// Mixture Modelling algorithm.
+///</summary>
+struct GmmOptions
+{
+    ///<summary>
+    /// Multiplied by estimated average width of the peak in the spectrum.
+    /// Defines resolutioon of the decomposition.
+    ///</summary>
+    DataType resolution = 0.5;
+
+    ///<summary>
+    /// Determines peak detection sensitivity.
+    /// Used for finding split peaks. A height of a single peak must be greater
+    /// than the product of this parameter and height of the highest peak.
+    ///</summary>
+    DataType sensitivity = 0;
+
+    ///<summary>
+    /// Determines peak quality threshold.
+    /// Used for finding split peaks. Split peaks must have
+    /// a higher quality value than this parameter to be accepted.
+    ///</summary>
+    DataType qualityThreshold = 1.3;
+
+    ///<summary>
+    /// Determines an initial offset from peak list during clear peaks search.
+    ///</summary>
+    Index initialJump = 5;
+
+    ///<summary>
+    /// Determines a peak lookup range during clear peaks search.
+    ///</summary>
+    Index peakLookupRange = 4;
+
+    ///<summary>
+    /// Determines a minimal offset from current offset in peak list during clear
+    /// peaks search.
+    ///</summary>
+    Index minJump = 4;
+
+    ///<summary>
+    /// Used in quality function during dynamic programming initialization.
+    ///</summary>
+    DataType qualityFunctionParam = 0.5; // todo(mgallus): find better name.
+
+    ///<summary>
+    /// Used in EM iterations to define lower bounds for standard deviation.
+    ///</summary>
+    DataType minStd = 0.1;
+
+    ///<summary>
+    /// Weight used to pick the best gmm decomposition of splitting segments
+    /// penalty coefficient for a number of components in the quality funtion.
+    /// The number of components is multiplied by this coefficient to obtain
+    /// the penalty for using a particular amount of components.
+    ///</summary>
+    DataType splittingPenaltyCoefficient = 0.0001;
+
+    ///<summary>
+    /// Used to determine the minimal amount of iterations to be performed
+    /// when searching for most accurate number of gaussian components in
+    /// splitter segment decomposition.
+    ///</summary>
+    Index maxComponentSearchIterations = 15; // todo(mgallus): find better name.
+
+    ///<summary>
+    /// Weight used to pick the best gmm decomposition of segments
+    /// penalty coefficient for a number of components in the quality funtion.
+    ///</summary>
+    DataType segmentPenaltyCoefficient = 0.001;
+
+    ///<summary>
+    /// Used to determine the max amount of iterations to be performed
+    /// when searching for most accurate number of gaussian components in
+    /// segment decomposition.
+    ///</summary>
+    Index minComponentSearchIterations = 30; // todo(mgallus): find better name.
+
+    ///<summary>
+    /// Used to determine the max amount of components used to build up a
+    /// splitter.
+    ///</summary>
+    Index maxComponentsNumForSplitter = 10;
+
+    ///<summary>
+    /// Used to determine the max amount of components used to build up a
+    /// segment.
+    ///</summary>
+    Index maxComponentsNumForSegment = 30;
+
+    ///<summary>
+    /// Tolerance of parameters change (mean, variance, peak height) for
+    /// Expectation Maximization.
+    ///</summary>
+    DataType emEpsilon = 0.0001;
+};
+}

--- a/src/Spectre.libGaussianMixtureModelling/Spectre.libGaussianMixtureModelling.vcxproj
+++ b/src/Spectre.libGaussianMixtureModelling/Spectre.libGaussianMixtureModelling.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="ClearPeakFinder.h" />
     <ClInclude Include="DataTypes.h" />
     <ClInclude Include="GmmOptions.h" />
     <ClInclude Include="Matrix.h" />
@@ -34,6 +35,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="ClearPeakFinder.cpp" />
     <ClCompile Include="ExpectationMaximization.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/src/Spectre.libGaussianMixtureModelling/Spectre.libGaussianMixtureModelling.vcxproj
+++ b/src/Spectre.libGaussianMixtureModelling/Spectre.libGaussianMixtureModelling.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DataTypes.h" />
+    <ClInclude Include="GmmOptions.h" />
     <ClInclude Include="Matrix.h" />
     <ClInclude Include="RandomInitializationRef.h" />
     <ClInclude Include="ExpectationMaximization.h" />

--- a/src/Spectre.libGaussianMixtureModelling/Spectre.libGaussianMixtureModelling.vcxproj.filters
+++ b/src/Spectre.libGaussianMixtureModelling/Spectre.libGaussianMixtureModelling.vcxproj.filters
@@ -38,6 +38,9 @@
     <ClInclude Include="DataTypes.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="GmmOptions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Spectre.libGaussianMixtureModelling/Spectre.libGaussianMixtureModelling.vcxproj.filters
+++ b/src/Spectre.libGaussianMixtureModelling/Spectre.libGaussianMixtureModelling.vcxproj.filters
@@ -38,6 +38,9 @@
     <ClInclude Include="DataTypes.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ClearPeakFinder.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="GmmOptions.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -47,6 +50,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ExpectationMaximization.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="ClearPeakFinder.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/native-algorithms.sln
+++ b/src/native-algorithms.sln
@@ -24,6 +24,7 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Spectre.libGaussianMixtureModelling.Tests", "Spectre.libGaussianMixtureModelling.Tests\Spectre.libGaussianMixtureModelling.Tests.vcxproj", "{2185C120-7B01-4E2E-B200-858A2D25C715}"
 	ProjectSection(ProjectDependencies) = postProject
 		{7417BF00-028B-4797-B58A-6058CA338493} = {7417BF00-028B-4797-B58A-6058CA338493}
+		{104D9A93-F6D7-4BF4-961F-7C52FEAEA77B} = {104D9A93-F6D7-4BF4-961F-7C52FEAEA77B}
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Spectre.libGaussianMixtureModelling", "Spectre.libGaussianMixtureModelling\Spectre.libGaussianMixtureModelling.vcxproj", "{104D9A93-F6D7-4BF4-961F-7C52FEAEA77B}"


### PR DESCRIPTION
The feature introduces a module for finding clear (aka splitting) peaks among the provided list of peaks, using user-supplied parameters and pre-calculated peak qualities.

To shed a bit more light on how does it work:
1. Using FindOffset, the function determines a new interval in which the clear peaks will be searched.
2. All peaks contained in interval are then filtered out if their quality or height aren't satisfactory and the highest of those who have remained is chosen as a clear peak of the interval. Index of that "best" peak is then returned. If there were no peaks satisfying conditions found, function returns a special index indicating that.
3. Go to step 1 and repeat until reaching the end of peak array.

Btw. sorry for FindClearPeaks being this long. Believe it or not, but I've spent ~3-4h on trying to make it smaller, and that's the furthest I could get it to.