### PR TITLE
Provide CMake support under Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ x64/
 x86/
 bld/
 [Bb]in/
+[Bb]uild/
 [Oo]bj/
 [Ll]og/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,426 @@
+cmake_minimum_required(VERSION 3.0)
+project(spectre_native_algorithms CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(OpenCV REQUIRED)
+find_package(GMock REQUIRED)
+
+include_directories(src)
+
+
+add_library(Spectre.libClassifier STATIC
+        src/Spectre.libClassifier/ConfusionMatrix.cpp
+        src/Spectre.libClassifier/ConfusionMatrix.h
+        src/Spectre.libClassifier/DatasetFilter.h
+        src/Spectre.libClassifier/DownsampledOpenCVDataset.cpp
+        src/Spectre.libClassifier/DownsampledOpenCVDataset.h
+        src/Spectre.libClassifier/EmptyOpenCvDatasetException.cpp
+        src/Spectre.libClassifier/EmptyOpenCvDatasetException.h
+        src/Spectre.libClassifier/ExcessiveTrainingRateException.cpp
+        src/Spectre.libClassifier/ExcessiveTrainingRateException.h
+        src/Spectre.libClassifier/IClassifier.h
+        src/Spectre.libClassifier/InsufficientDataException.cpp
+        src/Spectre.libClassifier/InsufficientDataException.h
+        src/Spectre.libClassifier/NegativeTrainingRateException.cpp
+        src/Spectre.libClassifier/NegativeTrainingRateException.h
+        src/Spectre.libClassifier/NotABinaryLabelException.cpp
+        src/Spectre.libClassifier/NotABinaryLabelException.h
+        src/Spectre.libClassifier/ObservationExtractor.cpp
+        src/Spectre.libClassifier/ObservationExtractor.h
+        src/Spectre.libClassifier/OpenCvDataset.cpp
+        src/Spectre.libClassifier/OpenCvDataset.h
+        src/Spectre.libClassifier/RandomSplitter.cpp
+        src/Spectre.libClassifier/RandomSplitter.h
+        src/Spectre.libClassifier/SplittedOpenCvDataset.cpp
+        src/Spectre.libClassifier/SplittedOpevCvDataset.h
+        src/Spectre.libClassifier/Svm.cpp
+        src/Spectre.libClassifier/Types.h
+        src/Spectre.libClassifier/UnsupportedDatasetTypeException.h
+        src/Spectre.libClassifier/UntrainedClassifierException.h
+        )
+
+
+add_library(Spectre.libClustering STATIC
+        src/Spectre.libClustering/Partition.cpp
+        src/Spectre.libClustering/Partition.h
+        )
+
+
+add_library(Spectre.libDataset STATIC
+        src/Spectre.libDataset/Dataset.h
+        src/Spectre.libDataset/Empty.cpp
+        src/Spectre.libDataset/Empty.h
+        src/Spectre.libDataset/IDataset.h
+        src/Spectre.libDataset/InconsistentInputSizeException.cpp
+        src/Spectre.libDataset/InconsistentInputSizeException.h
+        src/Spectre.libDataset/IReadOnlyDataset.h
+        )
+
+
+add_library(Spectre.libDivik STATIC
+        src/Spectre.libDivik/DivikResultStruct.cpp
+        src/Spectre.libDivik/DivikResultStruct.h
+        )
+
+
+add_library(Spectre.libException STATIC
+        src/Spectre.libException/ArgumentOutOfRangeException.h
+        src/Spectre.libException/EmptyArgumentException.cpp
+        src/Spectre.libException/EmptyArgumentException.h
+        src/Spectre.libException/EmptyDatasetException.cpp
+        src/Spectre.libException/EmptyDatasetException.h
+        src/Spectre.libException/ExceptionBase.cpp
+        src/Spectre.libException/ExceptionBase.h
+        src/Spectre.libException/InconsistentArgumentSizesException.cpp
+        src/Spectre.libException/InconsistentArgumentSizesException.h
+        src/Spectre.libException/NullPointerException.cpp
+        src/Spectre.libException/NullPointerException.h
+        src/Spectre.libException/OutOfRangeException.cpp
+        src/Spectre.libException/OutOfRangeException.h
+        src/Spectre.libException/ReachedUnreachableCodeException.cpp
+        src/Spectre.libException/ReachedUnreachableCodeException.h
+        )
+
+
+add_library(Spectre.libFunctional STATIC
+        src/Spectre.libFunctional/Filter.h
+        src/Spectre.libFunctional/Find.cpp
+        src/Spectre.libFunctional/Find.h
+        src/Spectre.libFunctional/Range.h
+        src/Spectre.libFunctional/Transform.h
+        src/Spectre.libFunctional/ZeroStepException.cpp
+        src/Spectre.libFunctional/ZeroStepException.h
+        )
+
+
+add_library(Spectre.libGaClassifier STATIC
+        src/Spectre.libGaClassifier/AllLabelTypesIncludedCondition.cpp
+        src/Spectre.libGaClassifier/AllLabelTypesIncludedCondition.h
+        src/Spectre.libGaClassifier/ClassifierFitnessFunction.cpp
+        src/Spectre.libGaClassifier/ClassifierFitnessFunction.h
+        src/Spectre.libGaClassifier/GaClassifier.cpp
+        src/Spectre.libGaClassifier/GaClassifier.h
+        src/Spectre.libGaClassifier/IndividualFeasibilityConditionsFactory.cpp
+        src/Spectre.libGaClassifier/IndividualFeasibilityConditionsFactory.h
+        )
+
+
+add_library(Spectre.libGaussianMixtureModelling STATIC
+        src/Common/DataTypes.h
+        src/Spectre.libGaussianMixtureModelling/ClearPeakFinder.cpp
+        src/Spectre.libGaussianMixtureModelling/ClearPeakFinder.h
+        src/Spectre.libGaussianMixtureModelling/DataTypes.h
+        src/Spectre.libGaussianMixtureModelling/DynamicProgrammingInitialization.h
+        src/Spectre.libGaussianMixtureModelling/ExpectationMaximization.cpp
+        src/Spectre.libGaussianMixtureModelling/ExpectationMaximization.h
+        src/Spectre.libGaussianMixtureModelling/ExpectationRunnerRef.h
+        src/Spectre.libGaussianMixtureModelling/GaussianDistribution.h
+        src/Spectre.libGaussianMixtureModelling/GaussianMixtureModel.h
+        src/Spectre.libGaussianMixtureModelling/GmmOptions.h
+        src/Spectre.libGaussianMixtureModelling/LogLikelihoodCalculator.h
+        src/Spectre.libGaussianMixtureModelling/Matrix.h
+        src/Spectre.libGaussianMixtureModelling/MaximizationRunnerRef.h
+        src/Spectre.libGaussianMixtureModelling/RandomInitializationRef.h
+        src/Spectre.libGaussianMixtureModelling/SplitterSegmentExtractor.cpp
+        src/Spectre.libGaussianMixtureModelling/SplitterSegmentExtractor.h
+        )
+
+
+add_library(Spectre.libGenetic STATIC
+        src/Spectre.libGenetic/BaseIndividualFeasibilityCondition.cpp
+        src/Spectre.libGenetic/BaseIndividualFeasibilityCondition.h
+        src/Spectre.libGenetic/CrossoverOperator.cpp
+        src/Spectre.libGenetic/CrossoverOperator.h
+        src/Spectre.libGenetic/DataTypes.h
+        src/Spectre.libGenetic/ExcessivePreservationRateException.cpp
+        src/Spectre.libGenetic/ExcessivePreservationRateException.h
+        src/Spectre.libGenetic/FitnessFunction.h
+        src/Spectre.libGenetic/Generation.cpp
+        src/Spectre.libGenetic/Generation.h
+        src/Spectre.libGenetic/GenerationFactory.cpp
+        src/Spectre.libGenetic/GenerationFactory.h
+        src/Spectre.libGenetic/GeneticAlgorithm.cpp
+        src/Spectre.libGenetic/GeneticAlgorithm.h
+        src/Spectre.libGenetic/GeneticAlgorithmFactory.cpp
+        src/Spectre.libGenetic/GeneticAlgorithmFactory.h
+        src/Spectre.libGenetic/InconsistentChromosomeLengthException.cpp
+        src/Spectre.libGenetic/InconsistentChromosomeLengthException.h
+        src/Spectre.libGenetic/InconsistentGenerationAndScoresLengthException.cpp
+        src/Spectre.libGenetic/InconsistentGenerationAndScoresLengthException.h
+        src/Spectre.libGenetic/InconsistentMinimalAndMaximalFillupException.cpp
+        src/Spectre.libGenetic/InconsistentMinimalAndMaximalFillupException.h
+        src/Spectre.libGenetic/Individual.cpp
+        src/Spectre.libGenetic/Individual.h
+        src/Spectre.libGenetic/IndividualsBuilderStrategy.cpp
+        src/Spectre.libGenetic/IndividualsBuilderStrategy.h
+        src/Spectre.libGenetic/LengthCondition.cpp
+        src/Spectre.libGenetic/LengthCondition.h
+        src/Spectre.libGenetic/MaximalFillupCondition.cpp
+        src/Spectre.libGenetic/MaximalFillupCondition.h
+        src/Spectre.libGenetic/MaximalPercentageFillupCondition.cpp
+        src/Spectre.libGenetic/MaximalPercentageFillupCondition.h
+        src/Spectre.libGenetic/MinimalFillupCondition.cpp
+        src/Spectre.libGenetic/MinimalFillupCondition.h
+        src/Spectre.libGenetic/MinimalPercentageFillupCondition.cpp
+        src/Spectre.libGenetic/MinimalPercentageFillupCondition.h
+        src/Spectre.libGenetic/MutationOperator.cpp
+        src/Spectre.libGenetic/MutationOperator.h
+        src/Spectre.libGenetic/NegativePreservationRateException.cpp
+        src/Spectre.libGenetic/NegativePreservationRateException.h
+        src/Spectre.libGenetic/OffspringGenerator.cpp
+        src/Spectre.libGenetic/OffspringGenerator.h
+        src/Spectre.libGenetic/ParentSelectionStrategy.cpp
+        src/Spectre.libGenetic/ParentSelectionStrategy.h
+        src/Spectre.libGenetic/PreservationStrategy.cpp
+        src/Spectre.libGenetic/PreservationStrategy.h
+        src/Spectre.libGenetic/Scorer.cpp
+        src/Spectre.libGenetic/Scorer.h
+        src/Spectre.libGenetic/Sorting.h
+        src/Spectre.libGenetic/StopCondition.cpp
+        src/Spectre.libGenetic/StopCondition.h
+        )
+
+
+add_library(Spectre.libHeatmapDataScaling STATIC
+        src/Spectre.libHeatmapDataScaling/HeatmapDataScalingAlgorithm.h
+        src/Spectre.libHeatmapDataScaling/Normalization.cpp
+        src/Spectre.libHeatmapDataScaling/Normalization.h
+        )
+
+
+add_library(Spectre.libPeakFinder STATIC
+        src/Common/DataTypes.h
+        src/Spectre.libPeakFinder/ExtremaFinder.cpp
+        src/Spectre.libPeakFinder/ExtremaFinder.h
+        src/Spectre.libPeakFinder/FWHHCalculator.cpp
+        src/Spectre.libPeakFinder/FWHHCalculator.h
+        src/Spectre.libPeakFinder/PeakFinder.cpp
+        src/Spectre.libPeakFinder/PeakFinder.h
+        src/Spectre.libPeakFinder/PeakQualityCalculator.cpp
+        src/Spectre.libPeakFinder/PeakQualityCalculator.h
+        )
+
+
+add_library(Spectre.libStatistics STATIC
+        src/Spectre.libStatistics/CohenEffectSize.cpp
+        src/Spectre.libStatistics/CohenEffectSize.h
+        src/Spectre.libStatistics/DifferentiatingFeaturesEstimator.cpp
+        src/Spectre.libStatistics/DifferentiatingFeaturesEstimator.h
+        src/Spectre.libStatistics/InconsistentNumberOfFeaturesException.cpp
+        src/Spectre.libStatistics/InconsistentNumberOfFeaturesException.h
+        src/Spectre.libStatistics/Math.h
+        src/Spectre.libStatistics/StatisticalIndex.cpp
+        src/Spectre.libStatistics/StatisticalIndex.h
+        src/Spectre.libStatistics/Statistics.h
+        src/Spectre.libStatistics/Types.h
+        src/Spectre.libStatistics/ValuesHomogeneityEstimator.h
+        )
+
+
+add_library(Spectre.libWavelet STATIC
+        src/Common/DataTypes.h
+        src/Spectre.libWavelet/AlgorithmConstants.h
+        src/Spectre.libWavelet/Convolution.cpp
+        src/Spectre.libWavelet/Convolution.h
+        src/Spectre.libWavelet/DataTypes.h
+        src/Spectre.libWavelet/DaubechiesFiltersDenoiser.cpp
+        src/Spectre.libWavelet/DaubechiesFiltersDenoiser.h
+        src/Spectre.libWavelet/MedianAbsoluteDeviationNoiseEstimator.cpp
+        src/Spectre.libWavelet/MedianAbsoluteDeviationNoiseEstimator.h
+        src/Spectre.libWavelet/PrecomputedDaubechiesCoefficients.h
+        src/Spectre.libWavelet/SoftThresholder.cpp
+        src/Spectre.libWavelet/SoftThresholder.h
+        src/Spectre.libWavelet/WaveletCoefficients.h
+        src/Spectre.libWavelet/WaveletDecomposerRef.cpp
+        src/Spectre.libWavelet/WaveletDecomposerRef.h
+        src/Spectre.libWavelet/WaveletReconstructorRef.cpp
+        src/Spectre.libWavelet/WaveletReconstructorRef.h
+        src/Spectre.libWavelet/WaveletUtils.h
+        )
+
+
+add_executable(Spectre.libClassifier.Tests
+        src/Spectre.libClassifier.Tests/DownsampledOpenCVDatasetTest.cpp
+        src/Spectre.libClassifier.Tests/ObservationExtractorTest.cpp
+        src/Spectre.libClassifier.Tests/OpenCvDatasetTest.cpp
+        src/Spectre.libClassifier.Tests/RandomSplitterTest.cpp
+        src/Spectre.libClassifier.Tests/SplittedOpenCVDatasetTest.cpp
+        src/Spectre.libClassifier.Tests/SvmTest.cpp
+        )
+target_link_libraries(Spectre.libClassifier.Tests
+        Spectre.libDataset
+        Spectre.libFunctional
+        Spectre.libClassifier
+        ${OpenCV_LIBS}
+        gtest
+        gtest_main
+        )
+add_test(Spectre.libClassifier.Tests Spectre.libClassifier.Tests)
+
+
+add_executable(Spectre.libClustering.Tests
+        src/Spectre.libClustering.Tests/PartitionTest.cpp
+        )
+target_link_libraries(Spectre.libClustering.Tests
+        Spectre.libClustering
+        gtest
+        gtest_main
+        )
+add_test(Spectre.libClustering.Tests Spectre.libClustering.Tests)
+
+
+add_executable(Spectre.libDataset.Tests
+        src/Spectre.libDataset.Tests/DatasetTest.cpp
+        )
+target_link_libraries(Spectre.libDataset.Tests
+        Spectre.libDataset
+        gtest
+        gtest_main
+        )
+add_test(Spectre.libDataset.Tests Spectre.libDataset.Tests)
+
+
+add_executable(Spectre.libFunctional.Tests
+        src/Spectre.libFunctional.Tests/FilterTest.cpp
+        src/Spectre.libFunctional.Tests/FindTest.cpp
+        src/Spectre.libFunctional.Tests/RangeTest.cpp
+        src/Spectre.libFunctional.Tests/TransformTest.cpp
+        )
+target_link_libraries(Spectre.libFunctional.Tests
+        Spectre.libFunctional
+        gtest
+        gtest_main
+        )
+add_test(Spectre.libFunctional.Tests Spectre.libFunctional.Tests)
+
+
+add_executable(Spectre.libGaClassifier.Tests
+        src/Spectre.libGaClassifier.Tests/AllLabelTypesIncludedConditionTest.cpp
+        src/Spectre.libGaClassifier.Tests/ClassifierFitnessFunctionTest.cpp
+        src/Spectre.libGaClassifier.Tests/GaClassifierTest.cpp
+        src/Spectre.libGaClassifier.Tests/IndividualFeasibilityConditionsFactoryTest.cpp
+        )
+target_link_libraries(Spectre.libGaClassifier.Tests
+        Spectre.libGaClassifier
+        Spectre.libGenetic
+        Spectre.libClassifier
+        Spectre.libDataset
+        Spectre.libFunctional
+        ${OpenCV_LIBS}
+        gomp
+        gtest
+        gtest_main
+        )
+add_test(Spectre.libGaClassifier.Tests Spectre.libGaClassifier.Tests)
+
+
+add_executable(Spectre.libGaussianMixtureModelling.Tests
+        src/Spectre.libGaussianMixtureModelling.Tests/ClearPeakFinderTest.cpp
+        src/Spectre.libGaussianMixtureModelling.Tests/DynamicProgramminInitializationTest.cpp
+        src/Spectre.libGaussianMixtureModelling.Tests/ExpectationMaximizationTest.cpp
+        src/Spectre.libGaussianMixtureModelling.Tests/GaussianMixtureModelTest.cpp
+        src/Spectre.libGaussianMixtureModelling.Tests/SplitterSegmentExtractorTest.cpp
+        )
+target_link_libraries(Spectre.libGaussianMixtureModelling.Tests
+        Spectre.libGaussianMixtureModelling
+        gtest
+        gtest_main
+        )
+add_test(Spectre.libGaussianMixtureModelling.Tests Spectre.libGaussianMixtureModelling.Tests)
+
+
+add_executable(Spectre.libGenetic.Tests
+        src/Spectre.libGenetic.Tests/BaseIndividualFeasibilityConditionTest.cpp
+        src/Spectre.libGenetic.Tests/CrossoverOperatorTest.cpp
+        src/Spectre.libGenetic.Tests/GenerationFactoryTest.cpp
+        src/Spectre.libGenetic.Tests/GenerationTest.cpp
+        src/Spectre.libGenetic.Tests/GeneticAlgorithmTest.cpp
+        src/Spectre.libGenetic.Tests/IndividualsBuilderStrategyTest.cpp
+        src/Spectre.libGenetic.Tests/IndividualTest.cpp
+        src/Spectre.libGenetic.Tests/LengthConditionTest.cpp
+        src/Spectre.libGenetic.Tests/MaximalFillupConditionTest.cpp
+        src/Spectre.libGenetic.Tests/MaximalPercentageFillupConditionTest.cpp
+        src/Spectre.libGenetic.Tests/MinimalFillupConditionTest.cpp
+        src/Spectre.libGenetic.Tests/MinimalPercentageFillupConditionTest.cpp
+        src/Spectre.libGenetic.Tests/MockBaseIndividualFeasibilityCondition.h
+        src/Spectre.libGenetic.Tests/MockCrossoverOperator.h
+        src/Spectre.libGenetic.Tests/MockFitnessFunction.h
+        src/Spectre.libGenetic.Tests/MockIndividualsBuilderStrategy.h
+        src/Spectre.libGenetic.Tests/MockMutationOperator.h
+        src/Spectre.libGenetic.Tests/MockOffspringGenerator.h
+        src/Spectre.libGenetic.Tests/MockParentSelectionStrategy.h
+        src/Spectre.libGenetic.Tests/MockPreservationStrategy.h
+        src/Spectre.libGenetic.Tests/MockScorer.h
+        src/Spectre.libGenetic.Tests/MockStopCondition.h
+        src/Spectre.libGenetic.Tests/MutationOperatorTest.cpp
+        src/Spectre.libGenetic.Tests/OffspringGeneratorTest.cpp
+        src/Spectre.libGenetic.Tests/ParentSelectionStrategyTest.cpp
+        src/Spectre.libGenetic.Tests/PreservationStrategyTest.cpp
+        src/Spectre.libGenetic.Tests/ScorerTest.cpp
+        src/Spectre.libGenetic.Tests/StopConditionTest.cpp
+        )
+target_link_libraries(Spectre.libGenetic.Tests
+        Spectre.libGenetic
+        gomp
+        gmock
+        gtest
+        gtest_main
+        )
+add_test(Spectre.libGenetic.Tests Spectre.libGenetic.Tests)
+
+
+add_executable(Spectre.libPeakFinder.Tests
+        src/Spectre.libPeakFinder.Tests/ExtremaFinderTest.cpp
+        src/Spectre.libPeakFinder.Tests/FWHHCalculatorTest.cpp
+        src/Spectre.libPeakFinder.Tests/PeakQualityCalculatorTest.cpp
+        )
+target_link_libraries(Spectre.libPeakFinder.Tests
+        Spectre.libPeakFinder
+        gomp
+        gmock
+        gtest
+        gtest_main
+        )
+add_test(Spectre.libPeakFinder.Tests Spectre.libPeakFinder.Tests)
+
+
+add_executable(Spectre.libStatistics.Tests
+        src/Spectre.libStatistics.Tests/CohenEffectSizeTest.cpp
+        src/Spectre.libStatistics.Tests/DifferentiatingFeaturesEstimatorTest.cpp
+        src/Spectre.libStatistics.Tests/MathTest.cpp
+        src/Spectre.libStatistics.Tests/StatisticalIndexTest.cpp
+        src/Spectre.libStatistics.Tests/StatisticsTest.cpp
+        src/Spectre.libStatistics.Tests/ValuesHomogeneityEstimatorMock.h
+        )
+target_link_libraries(Spectre.libStatistics.Tests
+        Spectre.libException
+        Spectre.libDataset
+        Spectre.libStatistics
+        gomp
+        gmock
+        gtest
+        gtest_main
+        )
+add_test(Spectre.libStatistics.Tests Spectre.libStatistics.Tests)
+
+
+add_executable(Spectre.libWavelet.Tests
+        src/Spectre.libWavelet.Tests/ConvolutionTest.cpp
+        src/Spectre.libWavelet.Tests/DaubechiesFiltersDenoiserTest.cpp
+        src/Spectre.libWavelet.Tests/FloatingPointVectorMatcher.h
+        src/Spectre.libWavelet.Tests/MedianAbsoluteDeviationNoiseEstimatorTest.cpp
+        src/Spectre.libWavelet.Tests/SoftThresholderTest.cpp
+        src/Spectre.libWavelet.Tests/WaveletDecomposerRefTest.cpp
+        src/Spectre.libWavelet.Tests/WaveletReconstructorRefTest.cpp
+        )
+target_link_libraries(Spectre.libWavelet.Tests
+        Spectre.libFunctional
+        Spectre.libWavelet
+        gtest
+        gtest_main
+        )
+add_test(Spectre.libWavelet.Tests Spectre.libWavelet.Tests)
+
+
+enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ project(spectre_native_algorithms CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+find_package(OpenMP REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(GMock REQUIRED)
 
@@ -313,7 +316,7 @@ target_link_libraries(Spectre.libGaClassifier.Tests
         Spectre.libException
         Spectre.libFunctional
         ${OpenCV_LIBS}
-        gomp
+        omp
         gtest
         gtest_main
         )
@@ -369,7 +372,7 @@ add_executable(Spectre.libGenetic.Tests
 target_link_libraries(Spectre.libGenetic.Tests
         Spectre.libGenetic
         Spectre.libException
-        gomp
+        omp
         gmock
         gtest
         gtest_main
@@ -385,7 +388,6 @@ add_executable(Spectre.libPeakFinder.Tests
 target_link_libraries(Spectre.libPeakFinder.Tests
         Spectre.libPeakFinder
         Spectre.libException
-        gomp
         gmock
         gtest
         gtest_main
@@ -405,7 +407,7 @@ target_link_libraries(Spectre.libStatistics.Tests
         Spectre.libStatistics
         Spectre.libDataset
         Spectre.libException
-        gomp
+        omp
         gmock
         gtest
         gtest_main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,9 +249,10 @@ add_executable(Spectre.libClassifier.Tests
         src/Spectre.libClassifier.Tests/SvmTest.cpp
         )
 target_link_libraries(Spectre.libClassifier.Tests
-        Spectre.libDataset
-        Spectre.libFunctional
         Spectre.libClassifier
+        Spectre.libDataset
+        Spectre.libException
+        Spectre.libFunctional
         ${OpenCV_LIBS}
         gtest
         gtest_main
@@ -264,6 +265,7 @@ add_executable(Spectre.libClustering.Tests
         )
 target_link_libraries(Spectre.libClustering.Tests
         Spectre.libClustering
+        Spectre.libException
         gtest
         gtest_main
         )
@@ -275,6 +277,7 @@ add_executable(Spectre.libDataset.Tests
         )
 target_link_libraries(Spectre.libDataset.Tests
         Spectre.libDataset
+        Spectre.libException
         gtest
         gtest_main
         )
@@ -289,6 +292,7 @@ add_executable(Spectre.libFunctional.Tests
         )
 target_link_libraries(Spectre.libFunctional.Tests
         Spectre.libFunctional
+        Spectre.libException
         gtest
         gtest_main
         )
@@ -306,6 +310,7 @@ target_link_libraries(Spectre.libGaClassifier.Tests
         Spectre.libGenetic
         Spectre.libClassifier
         Spectre.libDataset
+        Spectre.libException
         Spectre.libFunctional
         ${OpenCV_LIBS}
         gomp
@@ -324,6 +329,7 @@ add_executable(Spectre.libGaussianMixtureModelling.Tests
         )
 target_link_libraries(Spectre.libGaussianMixtureModelling.Tests
         Spectre.libGaussianMixtureModelling
+        Spectre.libException
         gtest
         gtest_main
         )
@@ -362,6 +368,7 @@ add_executable(Spectre.libGenetic.Tests
         )
 target_link_libraries(Spectre.libGenetic.Tests
         Spectre.libGenetic
+        Spectre.libException
         gomp
         gmock
         gtest
@@ -377,6 +384,7 @@ add_executable(Spectre.libPeakFinder.Tests
         )
 target_link_libraries(Spectre.libPeakFinder.Tests
         Spectre.libPeakFinder
+        Spectre.libException
         gomp
         gmock
         gtest
@@ -394,9 +402,9 @@ add_executable(Spectre.libStatistics.Tests
         src/Spectre.libStatistics.Tests/ValuesHomogeneityEstimatorMock.h
         )
 target_link_libraries(Spectre.libStatistics.Tests
-        Spectre.libException
-        Spectre.libDataset
         Spectre.libStatistics
+        Spectre.libDataset
+        Spectre.libException
         gomp
         gmock
         gtest
@@ -415,8 +423,9 @@ add_executable(Spectre.libWavelet.Tests
         src/Spectre.libWavelet.Tests/WaveletReconstructorRefTest.cpp
         )
 target_link_libraries(Spectre.libWavelet.Tests
-        Spectre.libFunctional
         Spectre.libWavelet
+        Spectre.libException
+        Spectre.libFunctional
         gtest
         gtest_main
         )

--- a/cmake/FindOpenMP.cmake
+++ b/cmake/FindOpenMP.cmake
@@ -1,0 +1,332 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#.rst:
+# FindOpenMP
+# ----------
+#
+# Finds OpenMP support
+#
+# This module can be used to detect OpenMP support in a compiler.  If
+# the compiler supports OpenMP, the flags required to compile with
+# OpenMP support are returned in variables for the different languages.
+# The variables may be empty if the compiler does not need a special
+# flag to support OpenMP.
+#
+# The following variables are set:
+#
+# ``OpenMP_C_FLAGS``
+#   Flags to add to the C compiler for OpenMP support.
+# ``OpenMP_CXX_FLAGS``
+#   Flags to add to the CXX compiler for OpenMP support.
+# ``OpenMP_Fortran_FLAGS``
+#   Flags to add to the Fortran compiler for OpenMP support.
+# ``OPENMP_FOUND``
+#   True if openmp is detected.
+#
+# The following internal variables are set, if detected:
+#
+# ``OpenMP_C_SPEC_DATE``
+#   Specification date of OpenMP version of C compiler.
+# ``OpenMP_CXX_SPEC_DATE``
+#   Specification date of OpenMP version of CXX compiler.
+# ``OpenMP_Fortran_SPEC_DATE``
+#   Specification date of OpenMP version of Fortran compiler.
+#
+# The specification dates are formatted as integers of the form
+# ``CCYYMM`` where these represent the decimal digits of the century,
+# year, and month.
+
+message(STATUS "Looking for OpenMP")
+
+set(_OPENMP_REQUIRED_VARS)
+set(CMAKE_REQUIRED_QUIET_SAVE ${CMAKE_REQUIRED_QUIET})
+set(CMAKE_REQUIRED_QUIET ${OpenMP_FIND_QUIETLY})
+
+function(_OPENMP_FLAG_CANDIDATES LANG)
+  set(OpenMP_FLAG_CANDIDATES
+    #Empty, if compiler automatically accepts openmp
+    " "
+    #GNU
+    "-fopenmp"
+    #Clang
+    "-fopenmp=libiomp5"
+    "-fopenmp=libomp"
+    #Microsoft Visual Studio
+    "/openmp"
+    #Intel windows
+    "-Qopenmp"
+    #PathScale, Intel
+    "-openmp"
+    #Sun
+    "-xopenmp"
+    #HP
+    "+Oopenmp"
+    #IBM XL C/c++
+    "-qsmp"
+    #Portland Group, MIPSpro
+    "-mp"
+  )
+
+  set(OMP_FLAG_GNU "-fopenmp")
+  set(OMP_FLAG_Clang "-fopenmp=libomp")
+  set(OMP_FLAG_HP "+Oopenmp")
+  if(WIN32)
+    set(OMP_FLAG_Intel "-Qopenmp")
+  elseif(CMAKE_${LANG}_COMPILER_ID STREQUAL "Intel" AND
+         "${CMAKE_${LANG}_COMPILER_VERSION}" VERSION_LESS "15.0.0.20140528")
+    set(OMP_FLAG_Intel "-openmp")
+  else()
+    set(OMP_FLAG_Intel "-qopenmp")
+  endif()
+  set(OMP_FLAG_MIPSpro "-mp")
+  set(OMP_FLAG_MSVC "/openmp")
+  set(OMP_FLAG_PathScale "-openmp")
+  set(OMP_FLAG_PGI "-mp")
+  set(OMP_FLAG_SunPro "-xopenmp")
+  set(OMP_FLAG_XL "-qsmp")
+  set(OMP_FLAG_Cray " ")
+
+  # Move the flag that matches the compiler to the head of the list,
+  # this is faster and doesn't clutter the output that much. If that
+  # flag doesn't work we will still try all.
+  if(OMP_FLAG_${CMAKE_${LANG}_COMPILER_ID})
+    list(REMOVE_ITEM OpenMP_FLAG_CANDIDATES "${OMP_FLAG_${CMAKE_${LANG}_COMPILER_ID}}")
+    list(INSERT OpenMP_FLAG_CANDIDATES 0 "${OMP_FLAG_${CMAKE_${LANG}_COMPILER_ID}}")
+  endif()
+
+  set(OpenMP_${LANG}_FLAG_CANDIDATES "${OpenMP_FLAG_CANDIDATES}" PARENT_SCOPE)
+endfunction()
+
+# sample openmp source code to test
+set(OpenMP_C_TEST_SOURCE
+"
+#include <omp.h>
+int main() {
+#ifdef _OPENMP
+  return 0;
+#else
+  breaks_on_purpose
+#endif
+}
+")
+
+# same in Fortran
+set(OpenMP_Fortran_TEST_SOURCE
+  "
+      program test
+      use omp_lib
+      integer :: n
+      n = omp_get_num_threads()
+      end program test
+  "
+  )
+
+set(OpenMP_C_CXX_CHECK_VERSION_SOURCE
+"
+#include <stdio.h>
+#include <omp.h>
+const char ompver_str[] = { 'I', 'N', 'F', 'O', ':', 'O', 'p', 'e', 'n', 'M',
+                            'P', '-', 'd', 'a', 't', 'e', '[',
+                            ('0' + ((_OPENMP/100000)%10)),
+                            ('0' + ((_OPENMP/10000)%10)),
+                            ('0' + ((_OPENMP/1000)%10)),
+                            ('0' + ((_OPENMP/100)%10)),
+                            ('0' + ((_OPENMP/10)%10)),
+                            ('0' + ((_OPENMP/1)%10)),
+                            ']', '\\0' };
+int main(int argc, char *argv[])
+{
+  printf(\"%s\\n\", ompver_str);
+  return 0;
+}
+")
+
+set(OpenMP_Fortran_CHECK_VERSION_SOURCE
+"
+      program omp_ver
+      use omp_lib
+      integer, parameter :: zero = ichar('0')
+      integer, parameter :: ompv = openmp_version
+      character, dimension(24), parameter :: ompver_str =&
+      (/ 'I', 'N', 'F', 'O', ':', 'O', 'p', 'e', 'n', 'M', 'P', '-',&
+         'd', 'a', 't', 'e', '[',&
+         char(zero + mod(ompv/100000, 10)),&
+         char(zero + mod(ompv/10000, 10)),&
+         char(zero + mod(ompv/1000, 10)),&
+         char(zero + mod(ompv/100, 10)),&
+         char(zero + mod(ompv/10, 10)),&
+         char(zero + mod(ompv/1, 10)), ']' /)
+      print *, ompver_str
+      end program omp_ver
+")
+
+function(_OPENMP_GET_SPEC_DATE LANG SPEC_DATE)
+  set(WORK_DIR ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/FindOpenMP)
+  if("${LANG}" STREQUAL "C")
+    set(SRC_FILE ${WORK_DIR}/ompver.c)
+    file(WRITE ${SRC_FILE} "${OpenMP_C_CXX_CHECK_VERSION_SOURCE}")
+  elseif("${LANG}" STREQUAL "CXX")
+    set(SRC_FILE ${WORK_DIR}/ompver.cpp)
+    file(WRITE ${SRC_FILE} "${OpenMP_C_CXX_CHECK_VERSION_SOURCE}")
+  else() # ("${LANG}" STREQUAL "Fortran")
+    set(SRC_FILE ${WORK_DIR}/ompver.f90)
+    file(WRITE ${SRC_FILE} "${OpenMP_Fortran_CHECK_VERSION_SOURCE}")
+  endif()
+
+  set(BIN_FILE ${WORK_DIR}/ompver_${LANG}.bin)
+  try_compile(OpenMP_TRY_COMPILE_RESULT ${CMAKE_BINARY_DIR} ${SRC_FILE}
+              CMAKE_FLAGS "-DCOMPILE_DEFINITIONS:STRING=${OpenMP_${LANG}_FLAGS}"
+              COPY_FILE ${BIN_FILE})
+
+  if(${OpenMP_TRY_COMPILE_RESULT})
+    file(STRINGS ${BIN_FILE} specstr LIMIT_COUNT 1 REGEX "INFO:OpenMP-date")
+    set(regex_spec_date ".*INFO:OpenMP-date\\[0*([^]]*)\\].*")
+    if("${specstr}" MATCHES "${regex_spec_date}")
+      set(${SPEC_DATE} "${CMAKE_MATCH_1}" PARENT_SCOPE)
+    endif()
+  endif()
+
+  unset(OpenMP_TRY_COMPILE_RESULT CACHE)
+endfunction()
+
+
+# check c compiler
+if(CMAKE_C_COMPILER_LOADED)
+  # if these are set then do not try to find them again,
+  # by avoiding any try_compiles for the flags
+  if(OpenMP_C_FLAGS)
+    unset(OpenMP_C_FLAG_CANDIDATES)
+  else()
+    _OPENMP_FLAG_CANDIDATES("C")
+    include(CheckCSourceCompiles)
+  endif()
+
+  foreach(FLAG IN LISTS OpenMP_C_FLAG_CANDIDATES)
+    set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+    set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+    unset(OpenMP_FLAG_DETECTED CACHE)
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Try OpenMP C flag = [${FLAG}]")
+    endif()
+    check_c_source_compiles("${OpenMP_C_TEST_SOURCE}" OpenMP_FLAG_DETECTED)
+    set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+    if(OpenMP_FLAG_DETECTED)
+      set(OpenMP_C_FLAGS_INTERNAL "${FLAG}")
+      break()
+    endif()
+  endforeach()
+
+  set(OpenMP_C_FLAGS "${OpenMP_C_FLAGS_INTERNAL}"
+    CACHE STRING "C compiler flags for OpenMP parallization")
+
+  list(APPEND _OPENMP_REQUIRED_VARS OpenMP_C_FLAGS)
+  unset(OpenMP_C_FLAG_CANDIDATES)
+
+  if (NOT OpenMP_C_SPEC_DATE)
+    _OPENMP_GET_SPEC_DATE("C" OpenMP_C_SPEC_DATE_INTERNAL)
+    set(OpenMP_C_SPEC_DATE "${OpenMP_C_SPEC_DATE_INTERNAL}" CACHE
+      INTERNAL "C compiler's OpenMP specification date")
+  endif()
+endif()
+
+# check cxx compiler
+if(CMAKE_CXX_COMPILER_LOADED)
+  # if these are set then do not try to find them again,
+  # by avoiding any try_compiles for the flags
+  if(OpenMP_CXX_FLAGS)
+    unset(OpenMP_CXX_FLAG_CANDIDATES)
+  else()
+    _OPENMP_FLAG_CANDIDATES("CXX")
+    include(CheckCXXSourceCompiles)
+
+    # use the same source for CXX as C for now
+    set(OpenMP_CXX_TEST_SOURCE ${OpenMP_C_TEST_SOURCE})
+  endif()
+
+  foreach(FLAG IN LISTS OpenMP_CXX_FLAG_CANDIDATES)
+    set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+    set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+    unset(OpenMP_FLAG_DETECTED CACHE)
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Try OpenMP CXX flag = [${FLAG}]")
+    endif()
+    check_cxx_source_compiles("${OpenMP_CXX_TEST_SOURCE}" OpenMP_FLAG_DETECTED)
+    set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+    if(OpenMP_FLAG_DETECTED)
+      set(OpenMP_CXX_FLAGS_INTERNAL "${FLAG}")
+      break()
+    endif()
+  endforeach()
+  set(OpenMP_CXX_FLAGS "${OpenMP_CXX_FLAGS_INTERNAL}"
+    CACHE STRING "C++ compiler flags for OpenMP parallization")
+
+  list(APPEND _OPENMP_REQUIRED_VARS OpenMP_CXX_FLAGS)
+  unset(OpenMP_CXX_FLAG_CANDIDATES)
+
+  if (NOT OpenMP_CXX_SPEC_DATE)
+    _OPENMP_GET_SPEC_DATE("CXX" OpenMP_CXX_SPEC_DATE_INTERNAL)
+    set(OpenMP_CXX_SPEC_DATE "${OpenMP_CXX_SPEC_DATE_INTERNAL}" CACHE
+      INTERNAL "C++ compiler's OpenMP specification date")
+  endif()
+endif()
+
+# check Fortran compiler
+if(CMAKE_Fortran_COMPILER_LOADED)
+  # if these are set then do not try to find them again,
+  # by avoiding any try_compiles for the flags
+  if(OpenMP_Fortran_FLAGS)
+    unset(OpenMP_Fortran_FLAG_CANDIDATES)
+  else()
+    _OPENMP_FLAG_CANDIDATES("Fortran")
+    include(${CMAKE_CURRENT_LIST_DIR}/CheckFortranSourceCompiles.cmake)
+  endif()
+
+  foreach(FLAG IN LISTS OpenMP_Fortran_FLAG_CANDIDATES)
+    set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+    set(CMAKE_REQUIRED_FLAGS "${FLAG}")
+    unset(OpenMP_FLAG_DETECTED CACHE)
+    if(NOT CMAKE_REQUIRED_QUIET)
+      message(STATUS "Try OpenMP Fortran flag = [${FLAG}]")
+    endif()
+    check_fortran_source_compiles("${OpenMP_Fortran_TEST_SOURCE}" OpenMP_FLAG_DETECTED)
+    set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+    if(OpenMP_FLAG_DETECTED)
+      set(OpenMP_Fortran_FLAGS_INTERNAL "${FLAG}")
+      break()
+    endif()
+  endforeach()
+
+  set(OpenMP_Fortran_FLAGS "${OpenMP_Fortran_FLAGS_INTERNAL}"
+    CACHE STRING "Fortran compiler flags for OpenMP parallization")
+
+  list(APPEND _OPENMP_REQUIRED_VARS OpenMP_Fortran_FLAGS)
+  unset(OpenMP_Fortran_FLAG_CANDIDATES)
+
+  if (NOT OpenMP_Fortran_SPEC_DATE)
+    _OPENMP_GET_SPEC_DATE("Fortran" OpenMP_Fortran_SPEC_DATE_INTERNAL)
+    set(OpenMP_Fortran_SPEC_DATE "${OpenMP_Fortran_SPEC_DATE_INTERNAL}" CACHE
+      INTERNAL "Fortran compiler's OpenMP specification date")
+  endif()
+endif()
+
+set(CMAKE_REQUIRED_QUIET ${CMAKE_REQUIRED_QUIET_SAVE})
+
+if(_OPENMP_REQUIRED_VARS)
+  include(FindPackageHandleStandardArgs)
+
+  find_package_handle_standard_args(OpenMP
+                                    REQUIRED_VARS ${_OPENMP_REQUIRED_VARS})
+
+  mark_as_advanced(${_OPENMP_REQUIRED_VARS})
+
+  unset(_OPENMP_REQUIRED_VARS)
+else()
+  message(SEND_ERROR "FindOpenMP requires C or CXX language to be enabled")
+endif()
+
+unset(OpenMP_C_TEST_SOURCE)
+unset(OpenMP_CXX_TEST_SOURCE)
+unset(OpenMP_Fortran_TEST_SOURCE)
+unset(OpenMP_C_CXX_CHECK_VERSION_SOURCE)
+unset(OpenMP_Fortran_CHECK_VERSION_SOURCE)

--- a/src/Spectre.libClassifier/DownsampledOpenCVDataset.h
+++ b/src/Spectre.libClassifier/DownsampledOpenCVDataset.h
@@ -36,13 +36,13 @@ public:
     /// </summary>
     /// <param name="data">The dataset.</param>
     /// <param name="maximumSubsetSize">The maximum subset size.</param>
-    DownsampledOpenCVDataset::DownsampledOpenCVDataset(OpenCvDataset data, size_t maximumSubsetSize, double trainingRate);
+    DownsampledOpenCVDataset(OpenCvDataset data, size_t maximumSubsetSize, double trainingRate);
     /// <summary>
     /// Gets Splitted training and test dataset having the same amount cancer and noncancer cells.
     /// </summary>
     /// <param name="seed">The seed.</param>
     /// <returns>SplittedOpenCvDataset</returns>
-    SplittedOpenCvDataset DownsampledOpenCVDataset::getRandomSubset(Seed seed = 0) const;
+    SplittedOpenCvDataset getRandomSubset(Seed seed = 0) const;
 private:
     /// <summary>
     /// The cancer cells.
@@ -73,6 +73,6 @@ private:
     /// </summary>
     /// <param name="datasetSize">The dataset size.</param>
     /// <returns>vector of bool</returns>
-    std::vector<bool> DownsampledOpenCVDataset::getRandomFilter(size_t datasetSize, Seed seed) const;
+    std::vector<bool> getRandomFilter(size_t datasetSize, Seed seed) const;
 };
 }

--- a/src/Spectre.libClassifier/RandomSplitter.h
+++ b/src/Spectre.libClassifier/RandomSplitter.h
@@ -46,7 +46,7 @@ public:
     /// </summary>
     /// <param name="data">The data.</param>
     /// <returns>Dataset splitted into training and validation subsets.</returns>
-    SplittedOpenCvDataset RandomSplitter::split(const OpenCvDataset& data) const;
+    SplittedOpenCvDataset split(const OpenCvDataset& data) const;
 private:
     const double m_trainingRate;
     const Seed m_Seed;

--- a/src/Spectre.libClassifier/SplittedOpevCvDataset.h
+++ b/src/Spectre.libClassifier/SplittedOpevCvDataset.h
@@ -33,7 +33,7 @@ public:
     /// </summary>
     /// <param name="training">The training dataset.</param>
     /// <param name="test">The test dataset.</param>
-    SplittedOpenCvDataset::SplittedOpenCvDataset(OpenCvDataset&& training, OpenCvDataset&& test);
+    SplittedOpenCvDataset(OpenCvDataset&& training, OpenCvDataset&& test);
     /// <summary>
     /// The training set.
     /// </summary>

--- a/src/Spectre.libClassifier/Types.h
+++ b/src/Spectre.libClassifier/Types.h
@@ -30,5 +30,5 @@ namespace spectre::supervised
     const auto CV_TYPE = CV_32FC1;
     const auto CV_LABEL_TYPE = CV_32SC1;
     using RandomNumberGenerator = std::mt19937_64;
-    using Seed = _ULonglong; // @gmrukwa: from mt19937_64
+    using Seed = unsigned long long; // @gmrukwa: from mt19937_64
 }

--- a/src/Spectre.libClustering.Tests/PartitionTest.cpp
+++ b/src/Spectre.libClustering.Tests/PartitionTest.cpp
@@ -23,7 +23,7 @@ limitations under the License.
 #include <gsl/gsl>
 #include <vector>
 #include <algorithm>
-#include "Partition.h"
+#include "Spectre.libClustering/Partition.h"
 #include "Spectre.libException/NullPointerException.h"
 
 

--- a/src/Spectre.libDivik/DivikResultStruct.cpp
+++ b/src/Spectre.libDivik/DivikResultStruct.cpp
@@ -17,6 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <cmath>
 #include "DivikResultStruct.h"
 
 DivikResultStruct::DivikResultStruct()

--- a/src/Spectre.libException/ExceptionBase.cpp
+++ b/src/Spectre.libException/ExceptionBase.cpp
@@ -23,7 +23,7 @@ namespace spectre::core::exception
 {
 ExceptionBase::ExceptionBase(const std::string message): m_message(message) { }
 
-char const* ExceptionBase::what() const
+char const* ExceptionBase::what() const noexcept
 {
     return m_message.c_str();
 }

--- a/src/Spectre.libException/ExceptionBase.h
+++ b/src/Spectre.libException/ExceptionBase.h
@@ -39,7 +39,7 @@ public:
     /// Returns error message.
     /// </summary>
     /// <returns>Error message</returns>
-    char const* what() const override;
+    char const* what() const noexcept override;
 private:
     const std::string m_message;
 };

--- a/src/Spectre.libGaClassifier/AllLabelTypesIncludedCondition.cpp
+++ b/src/Spectre.libGaClassifier/AllLabelTypesIncludedCondition.cpp
@@ -36,7 +36,7 @@ bool AllLabelTypesIncludedCondition::checkCurrentCondition(const spectre::algori
     std::set<Label> types;
     for (auto i = 0u; i < individual.size(); ++i)
     {
-        if (individual.getData()[i])
+        if (individual[i])
         {
             types.insert(m_Labels[i]);
         }

--- a/src/Spectre.libGaClassifier/ClassifierFitnessFunction.cpp
+++ b/src/Spectre.libGaClassifier/ClassifierFitnessFunction.cpp
@@ -38,8 +38,7 @@ algorithm::genetic::ScoreType ClassifierFitnessFunction::operator()(const algori
     {
         throw core::exception::InconsistentArgumentSizesException("data", m_Data.trainingSet.size(), "individual", individual.size());
     }
-    auto individualData = individual.getData();
-    OpenCvDataset individualDataset = getFilteredOpenCvDataset(m_Data.trainingSet, individualData);
+    OpenCvDataset individualDataset = getFilteredOpenCvDataset(m_Data.trainingSet, individual);
 
     const auto result = getResultMatrix(std::move(individualDataset));
     return result.DiceIndex;

--- a/src/Spectre.libGaClassifier/GaClassifier.cpp
+++ b/src/Spectre.libGaClassifier/GaClassifier.cpp
@@ -76,8 +76,7 @@ void GaClassifier::Fit(LabeledDataset dataset)
     auto finalGeneration = algorithm->evolve(std::move(initialGeneration));
     auto bestIndividual = finalGeneration[0];
 
-    auto individualData = bestIndividual.getData();
-    OpenCvDataset bestDataset = getFilteredOpenCvDataset(splittedDataset.trainingSet, individualData);
+    OpenCvDataset bestDataset = getFilteredOpenCvDataset(splittedDataset.trainingSet, bestIndividual);
 
     m_Classifier->Fit(bestDataset);
 }

--- a/src/Spectre.libGaussianMixtureModelling.Tests/ClearPeakFinderTest.cpp
+++ b/src/Spectre.libGaussianMixtureModelling.Tests/ClearPeakFinderTest.cpp
@@ -19,9 +19,9 @@ limitations under the License.
 #define GTEST_LANG_CXX11 1
 
 #include <gtest/gtest.h>
-#include "ClearPeakFinder.h"
-#include "Spectre.libException\EmptyArgumentException.h"
-#include "Spectre.libException\InconsistentArgumentSizesException.h"
+#include "Spectre.libGaussianMixtureModelling/ClearPeakFinder.h"
+#include "Spectre.libException/EmptyArgumentException.h"
+#include "Spectre.libException/InconsistentArgumentSizesException.h"
 
 namespace spectre::unsupervised::gmm
 {

--- a/src/Spectre.libGaussianMixtureModelling.Tests/DynamicProgramminInitializationTest.cpp
+++ b/src/Spectre.libGaussianMixtureModelling.Tests/DynamicProgramminInitializationTest.cpp
@@ -21,7 +21,7 @@ limitations under the License.
 #define GTEST_LANG_CXX11 1
 
 #include <gtest/gtest.h>
-#include "DynamicProgrammingInitialization.h"
+#include "Spectre.libGaussianMixtureModelling/DynamicProgrammingInitialization.h"
 
 namespace spectre::unsupervised::gmm
 {

--- a/src/Spectre.libGaussianMixtureModelling.Tests/ExpectationMaximizationTest.cpp
+++ b/src/Spectre.libGaussianMixtureModelling.Tests/ExpectationMaximizationTest.cpp
@@ -20,11 +20,11 @@ limitations under the License.
 #define GTEST_LANG_CXX11 1
 
 #include <gtest/gtest.h>
-#include "ExpectationMaximization.h"
-#include "RandomInitializationRef.h"
-#include "ExpectationRunnerRef.h"
-#include "MaximizationRunnerRef.h"
-#include "LogLikelihoodCalculator.h"
+#include "Spectre.libGaussianMixtureModelling/ExpectationMaximization.h"
+#include "Spectre.libGaussianMixtureModelling/RandomInitializationRef.h"
+#include "Spectre.libGaussianMixtureModelling/ExpectationRunnerRef.h"
+#include "Spectre.libGaussianMixtureModelling/MaximizationRunnerRef.h"
+#include "Spectre.libGaussianMixtureModelling/LogLikelihoodCalculator.h"
 
 typedef std::mt19937_64 RandomNumberGenerator;
 

--- a/src/Spectre.libGaussianMixtureModelling.Tests/GaussianMixtureModelTest.cpp
+++ b/src/Spectre.libGaussianMixtureModelling.Tests/GaussianMixtureModelTest.cpp
@@ -22,7 +22,7 @@ limitations under the License.
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <stdlib.h>
-#include "GaussianMixtureModel.h"
+#include "Spectre.libGaussianMixtureModelling/GaussianMixtureModel.h"
 
 namespace spectre::unsupervised::gmm
 {

--- a/src/Spectre.libGaussianMixtureModelling.Tests/SplitterSegmentExtractorTest.cpp
+++ b/src/Spectre.libGaussianMixtureModelling.Tests/SplitterSegmentExtractorTest.cpp
@@ -19,7 +19,7 @@ limitations under the License.
 #define GTEST_LANG_CXX11 1
 
 #include <gtest/gtest.h>
-#include "Spectre.libGaussianMixtureModelling\SplitterSegmentExtractor.h"
+#include "Spectre.libGaussianMixtureModelling/SplitterSegmentExtractor.h"
 
 namespace spectre::unsupervised::gmm
 {

--- a/src/Spectre.libGaussianMixtureModelling/ClearPeakFinder.cpp
+++ b/src/Spectre.libGaussianMixtureModelling/ClearPeakFinder.cpp
@@ -17,9 +17,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 #include <stdexcept>
-#include "ClearPeakFinder.h"
-#include "Spectre.libException\EmptyArgumentException.h"
-#include "Spectre.libFunctional\Filter.h"
+#include "Spectre.libGaussianMixtureModelling/ClearPeakFinder.h"
+#include "Spectre.libException/EmptyArgumentException.h"
+#include "Spectre.libFunctional/Filter.h"
 
 using namespace spectre::core::functional;
 using namespace spectre::core::exception;

--- a/src/Spectre.libGaussianMixtureModelling/DataTypes.h
+++ b/src/Spectre.libGaussianMixtureModelling/DataTypes.h
@@ -18,7 +18,7 @@ limitations under the License.
 */
 #pragma once
 #include <random>
-#include "Common\DataTypes.h"
+#include "Common/DataTypes.h"
 
 namespace spectre::unsupervised::gmm
 {

--- a/src/Spectre.libGaussianMixtureModelling/DynamicProgrammingInitialization.h
+++ b/src/Spectre.libGaussianMixtureModelling/DynamicProgrammingInitialization.h
@@ -24,7 +24,7 @@ limitations under the License.
 #include <limits>
 #include "Matrix.h"
 #include <numeric>
-#include "Spectre.libException\OutOfRangeException.h"
+#include "Spectre.libException/OutOfRangeException.h"
 
 
 namespace spectre::unsupervised::gmm

--- a/src/Spectre.libGaussianMixtureModelling/ExpectationMaximization.h
+++ b/src/Spectre.libGaussianMixtureModelling/ExpectationMaximization.h
@@ -66,7 +66,7 @@ public:
     /// Gaussian Mixture Model containing all the components with their appropriate
     /// parameters.
     /// </returns>
-    GaussianMixtureModel ExpectationMaximization::EstimateGmm()
+    GaussianMixtureModel EstimateGmm()
     {
         constexpr DataType MIN_LIKELIHOOD_CHANGE = 0.00000001;
         Initialization();
@@ -90,19 +90,19 @@ public:
     }
 
 private:
-    void ExpectationMaximization::Initialization()
+    void Initialization()
     {
         m_Initialization.AssignRandomMeans();
         m_Initialization.AssignVariances();
         m_Initialization.AssignWeights();
     }
 
-    void ExpectationMaximization::Expectation()
+    void Expectation()
     {
         m_Expectation.Expectation();
     }
 
-    void ExpectationMaximization::Maximization()
+    void Maximization()
     {
         m_Maximization.UpdateWeights();
         m_Maximization.UpdateMeans();

--- a/src/Spectre.libGaussianMixtureModelling/ExpectationRunnerRef.h
+++ b/src/Spectre.libGaussianMixtureModelling/ExpectationRunnerRef.h
@@ -65,7 +65,7 @@ public:
     /// Fills affilation (gamma) matrix with probabilities of affilation of each sample
     /// to a certain gaussian component.
     /// </summary>
-    void ExpectationRunnerRef::Expectation()
+    void Expectation()
     {
         // This part conducts the instruction:
         // "Calculate gamma for each i and k

--- a/src/Spectre.libGaussianMixtureModelling/LogLikelihoodCalculator.h
+++ b/src/Spectre.libGaussianMixtureModelling/LogLikelihoodCalculator.h
@@ -62,7 +62,7 @@ public:
     /// <returns>
     /// Value of log likelihood.
     /// </returns>
-    DataType LogLikelihoodCalculator::CalculateLikelihood()
+    DataType CalculateLikelihood()
     {
         // This part performs calcluation of log likelihood
         // performed with accordance to equation (9.14)

--- a/src/Spectre.libGaussianMixtureModelling/MaximizationRunnerRef.h
+++ b/src/Spectre.libGaussianMixtureModelling/MaximizationRunnerRef.h
@@ -71,7 +71,7 @@ public:
     /// <summary>
     /// Updates weights in gaussian components, based on affilation (gamma) matrix.
     /// </summary>
-    void MaximizationRunnerRef::UpdateWeights()
+    void UpdateWeights()
     {
         // This part conducts the instruction:
         // "Using the gamma calculated in the Expectation step, 
@@ -98,7 +98,7 @@ public:
     /// <summary>
     /// Updates means in gaussian components, based on affilation (gamma) matrix.
     /// </summary>
-    void MaximizationRunnerRef::UpdateMeans()
+    void UpdateMeans()
     {
         // This part conducts the instruction:
         // "Using the gamma calculated in the Expectation step, 
@@ -122,7 +122,7 @@ public:
     /// Updates standard deviations in gaussian components, based on affilation 
     /// (gamma) matrix.
     /// </summary>
-    void MaximizationRunnerRef::UpdateStdDeviations()
+    void UpdateStdDeviations()
     {
         // This part conducts the instruction:
         // "Using the gamma calculated in the Expectation step, 

--- a/src/Spectre.libGaussianMixtureModelling/RandomInitializationRef.h
+++ b/src/Spectre.libGaussianMixtureModelling/RandomInitializationRef.h
@@ -61,7 +61,7 @@ public:
     /// <summary>
     /// Assigns means to gaussian components, by choosing random samples from the dataset.
     /// </summary>
-    void RandomInitializationRef::AssignRandomMeans()
+    void AssignRandomMeans()
     {
         // This part conducts the instruction:
         // "Randomly assign samples without replacement from the dataset"
@@ -78,7 +78,7 @@ public:
     /// Calculates variance of the dataset, and assigns its square root
     /// (standard deviation) to variances of all components.
     /// </summary>
-    void RandomInitializationRef::AssignVariances()
+    void AssignVariances()
     {
         // This part conducts the instruction:
         // "Set all component variance estimates to the sample variance"
@@ -96,7 +96,7 @@ public:
     /// Assigns uniform weight to each component. Each weight equals to
     /// 1 / K, and therefore they all sum to 1.
     /// </summary>
-    void RandomInitializationRef::AssignWeights()
+    void AssignWeights()
     {
         // This part conducts the instruction:
         // "Set all component distribution prior estimates to the uniform distribution"
@@ -110,7 +110,7 @@ public:
     }
 
 private:
-    DataType RandomInitializationRef::CalculateMean()
+    DataType CalculateMean()
     {
         DataType mean = 0.0;
 
@@ -122,7 +122,7 @@ private:
         return mean / (DataType)m_Mzs.size();
     }
 
-    DataType RandomInitializationRef::CalculateVariance(DataType mean)
+    DataType CalculateVariance(DataType mean)
     {
         DataType variance = 0.0;
 

--- a/src/Spectre.libGenetic.Tests/CrossoverOperatorTest.cpp
+++ b/src/Spectre.libGenetic.Tests/CrossoverOperatorTest.cpp
@@ -39,7 +39,7 @@ class CrossoverOperatorTest: public ::testing::Test
 public:
     CrossoverOperatorTest() {}
 protected:
-    const unsigned NUMBER_OF_TRIALS = 1000;
+    const unsigned NUMBER_OF_TRIALS = 2000;
     const double ALLOWED_MISS_RATE = 0.05;
     const Seed SEED = 0;
     const Individual true_individual = Individual({ true, true, true, true });
@@ -167,8 +167,8 @@ TEST_F(CrossoverOperatorTest, cuts_are_from_uniform_distribution)
     for (unsigned i = 0; i < counts.size(); ++i)
     {
         const auto count = counts[i];
-        EXPECT_GT(count, meanCount - allowedCountMiss) << i;
-        EXPECT_LT(count, meanCount + allowedCountMiss) << i;
+        EXPECT_GE(count, meanCount - allowedCountMiss) << i;
+        EXPECT_LE(count, meanCount + allowedCountMiss) << i;
     }
 }
 

--- a/src/Spectre.libGenetic.Tests/IndividualTest.cpp
+++ b/src/Spectre.libGenetic.Tests/IndividualTest.cpp
@@ -102,8 +102,8 @@ TEST_F(IndividualTest, iterators_allow_to_iterate_over_const_binary_data)
         ++dataIterator;
     }
 
-    EXPECT_EQ(individualIterator, mixedIndividual.end());
-    EXPECT_EQ(dataIterator, MIXED_DATA.end());
+    EXPECT_TRUE(individualIterator == mixedIndividual.end());
+    EXPECT_TRUE(dataIterator == MIXED_DATA.end());
 }
 
 TEST_F(IndividualTest, iterators_allow_to_read_and_modify_binary_data)
@@ -120,8 +120,8 @@ TEST_F(IndividualTest, iterators_allow_to_read_and_modify_binary_data)
         ++dataIterator;
     }
 
-    EXPECT_EQ(individualIterator, mutableIndividual.end());
-    EXPECT_EQ(dataIterator, MIXED_DATA.end());
+    EXPECT_TRUE(individualIterator == mutableIndividual.end());
+    EXPECT_TRUE(dataIterator == MIXED_DATA.end());
 
     individualIterator = mutableIndividual.begin();
     dataIterator = MIXED_DATA.begin();

--- a/src/Spectre.libGenetic.Tests/IndividualTest.cpp
+++ b/src/Spectre.libGenetic.Tests/IndividualTest.cpp
@@ -18,7 +18,6 @@ limitations under the License.
 */
 
 #include <gtest/gtest.h>
-#include "Spectre.libException/OutOfRangeException.h"
 #include "Spectre.libGenetic/Individual.h"
 #include "Spectre.libGenetic/InconsistentChromosomeLengthException.h"
 
@@ -60,17 +59,6 @@ TEST_F(IndividualTest, exhibit_proper_size)
 {
     const auto size = trueIndividual.size();
     EXPECT_EQ(size, TRUE_DATA.size());
-}
-
-TEST_F(IndividualTest, const_index_throws_for_exceeded_size)
-{
-    EXPECT_THROW(mixedIndividual[mixedIndividual.size()], spectre::core::exception::OutOfRangeException);
-}
-
-TEST_F(IndividualTest, mutable_index_throws_for_exceeded_size)
-{
-    Individual individual { std::vector<bool>(MIXED_DATA) };
-    EXPECT_THROW(individual[individual.size()] = false, spectre::core::exception::OutOfRangeException);
 }
 
 TEST_F(IndividualTest, index_returns_proper_const_bits)

--- a/src/Spectre.libGenetic/DataTypes.h
+++ b/src/Spectre.libGenetic/DataTypes.h
@@ -26,5 +26,5 @@ using ScoreType = double;
 using Label = signed;
 using RandomDevice = std::random_device;
 using RandomNumberGenerator = std::mt19937_64;
-using Seed = _ULonglong; // @gmrukwa: from mt19937_64
+using Seed = unsigned long long; // @gmrukwa: from mt19937_64
 }

--- a/src/Spectre.libGenetic/Individual.cpp
+++ b/src/Spectre.libGenetic/Individual.cpp
@@ -54,28 +54,4 @@ Individual& Individual::operator=(const Individual &other)
     }
 }
 
-std::vector<bool>::reference Individual::operator[](size_t index)
-{
-    if (index < size())
-    {
-        return (*this)[index];
-    }
-    else
-    {
-        throw OutOfRangeException(index, size());
-    }
-}
-
-std::vector<bool>::const_reference Individual::operator[](size_t index) const
-{
-    if (index < size())
-    {
-        return (*this)[index];
-    }
-    else
-    {
-        throw OutOfRangeException(index, size());
-    }
-}
-
 }

--- a/src/Spectre.libGenetic/Individual.cpp
+++ b/src/Spectre.libGenetic/Individual.cpp
@@ -31,11 +31,6 @@ namespace spectre::algorithm::genetic
 Individual::Individual(std::vector<bool> &&binaryData):
     std::vector<bool>(binaryData) { }
 
-const std::vector<bool>& Individual::getData() const
-{
-    return *this;
-}
-
 bool Individual::operator==(const Individual &other) const
 {
     return std::equal(begin(), end(), other.begin(), other.end());

--- a/src/Spectre.libGenetic/Individual.cpp
+++ b/src/Spectre.libGenetic/Individual.cpp
@@ -29,77 +29,28 @@ using namespace spectre::core::exception;
 namespace spectre::algorithm::genetic
 {
 Individual::Individual(std::vector<bool> &&binaryData):
-    m_BinaryData(binaryData) { }
+    std::vector<bool>(binaryData) { }
 
 const std::vector<bool>& Individual::getData() const
 {
-    return m_BinaryData;
-}
-
-std::vector<bool>::reference Individual::operator[](size_t index)
-{
-    if (index < m_BinaryData.size())
-    {
-        return m_BinaryData[index];
-    }
-    else
-    {
-        throw OutOfRangeException(index, m_BinaryData.size());
-    }
-}
-
-std::vector<bool>::const_reference Individual::operator[](size_t index) const
-{
-    if (index < m_BinaryData.size())
-    {
-        return m_BinaryData[index];
-    }
-    else
-    {
-        throw OutOfRangeException(index, m_BinaryData.size());
-    }
-}
-
-std::vector<bool>::iterator Individual::begin()
-{
-    return m_BinaryData.begin();
-}
-
-std::vector<bool>::iterator Individual::end()
-{
-    return m_BinaryData.end();
-}
-
-std::vector<bool>::const_iterator Individual::begin() const
-{
-    return m_BinaryData.begin();
-}
-
-std::vector<bool>::const_iterator Individual::end() const
-{
-    return m_BinaryData.end();
-}
-
-size_t Individual::size() const
-{
-    return m_BinaryData.size();
+    return *this;
 }
 
 bool Individual::operator==(const Individual &other) const
 {
-    return m_BinaryData == other.m_BinaryData;
+    return std::equal(begin(), end(), other.begin(), other.end());
 }
 
 bool Individual::operator!=(const Individual &other) const
 {
-    return !(this->operator==(other));
+    return !(*this == other);
 }
 
 Individual& Individual::operator=(const Individual &other)
 {
     if (size() == other.size())
     {
-        m_BinaryData.assign(other.m_BinaryData.begin(), other.m_BinaryData.end());
+        assign(other.begin(), other.end());
         return *this;
     }
     else

--- a/src/Spectre.libGenetic/Individual.cpp
+++ b/src/Spectre.libGenetic/Individual.cpp
@@ -53,4 +53,29 @@ Individual& Individual::operator=(const Individual &other)
         throw InconsistentChromosomeLengthException(size(), other.size());
     }
 }
+
+std::vector<bool>::reference Individual::operator[](size_t index)
+{
+    if (index < size())
+    {
+        return (*this)[index];
+    }
+    else
+    {
+        throw OutOfRangeException(index, size());
+    }
+}
+
+std::vector<bool>::const_reference Individual::operator[](size_t index) const
+{
+    if (index < size())
+    {
+        return (*this)[index];
+    }
+    else
+    {
+        throw OutOfRangeException(index, size());
+    }
+}
+
 }

--- a/src/Spectre.libGenetic/Individual.h
+++ b/src/Spectre.libGenetic/Individual.h
@@ -35,11 +35,6 @@ public:
     /// <param name="binaryData">The binary data.</param>
     explicit Individual(std::vector<bool> &&binaryData);
     /// <summary>
-    /// Gets the immutable data.
-    /// </summary>
-    /// <returns>Vector of binary data.</returns>
-    const std::vector<bool>& getData() const;
-    /// <summary>
     /// Compares object with other
     /// </summary>
     /// <param name="other">The other.</param>

--- a/src/Spectre.libGenetic/Individual.h
+++ b/src/Spectre.libGenetic/Individual.h
@@ -87,13 +87,13 @@ public:
     /// </summary>
     /// <param name="other">The other.</param>
     /// <returns>False, if binary data inside is the same.</returns>
-    bool Individual::operator!=(const Individual &other) const;
+    bool operator!=(const Individual &other) const;
     /// <summary>
     /// Overwrites individual with another object data.
     /// </summary>
     /// <param name="other">The other.</param>
     /// <returns>This instance.</returns>
-    Individual& Individual::operator=(const Individual &other);
+    Individual& operator=(const Individual &other);
     virtual ~Individual() = default;
 
 private:

--- a/src/Spectre.libGenetic/Individual.h
+++ b/src/Spectre.libGenetic/Individual.h
@@ -34,18 +34,35 @@ public:
     /// </summary>
     /// <param name="binaryData">The binary data.</param>
     explicit Individual(std::vector<bool> &&binaryData);
+
+    /// <summary>
+    /// Gets the mutable data under specified index.
+    /// </summary>
+    /// <param name="index">The index.</param>
+    /// <returns>Single bit of data.</returns>
+    reference operator[](size_t index);
+
+    /// <summary>
+    /// Gets the immutable data under specified index.
+    /// </summary>
+    /// <param name="index">The index.</param>
+    /// <returns>Single bit of data.</returns>
+    const_reference operator[](size_t index) const;
+
     /// <summary>
     /// Compares object with other
     /// </summary>
     /// <param name="other">The other.</param>
     /// <returns>True, if binary data inside is the same.</returns>
     bool operator==(const Individual &other) const;
+
     /// <summary>
     /// Compares object with other
     /// </summary>
     /// <param name="other">The other.</param>
     /// <returns>False, if binary data inside is the same.</returns>
     bool operator!=(const Individual &other) const;
+
     /// <summary>
     /// Overwrites individual with another object data.
     /// </summary>

--- a/src/Spectre.libGenetic/Individual.h
+++ b/src/Spectre.libGenetic/Individual.h
@@ -26,7 +26,7 @@ namespace spectre::algorithm::genetic
 /// <summary>
 /// Binary representation of an individual chromosome in genetic algorithm.
 /// </summary>
-class Individual
+class Individual : public std::vector<bool>
 {
 public:
     /// <summary>
@@ -39,43 +39,6 @@ public:
     /// </summary>
     /// <returns>Vector of binary data.</returns>
     const std::vector<bool>& getData() const;
-    /// <summary>
-    /// Gets the mutable data under specified index.
-    /// </summary>
-    /// <param name="index">The index.</param>
-    /// <returns>Single bit of data.</returns>
-    std::vector<bool>::reference operator[](size_t index);
-    /// <summary>
-    /// Gets the immutable data under specified index.
-    /// </summary>
-    /// <param name="index">The index.</param>
-    /// <returns>Single bit of data.</returns>
-    std::vector<bool>::const_reference operator[](size_t index) const;
-    /// <summary>
-    /// Return iterator for beginning of mutable sequence.
-    /// </summary>
-    /// <returns>Iterator for beginning of mutable sequence.</returns>
-    std::vector<bool>::iterator begin();
-    /// <summary>
-    /// Return iterator for after the end of mutable sequence.
-    /// </summary>
-    /// <returns>Iterator after the end of mutable sequence.</returns>
-    std::vector<bool>::iterator end();
-    /// <summary>
-    /// Return iterator for beginning of immutable sequence.
-    /// </summary>
-    /// <returns>Iterator for beginning of immutable sequence.</returns>
-    std::vector<bool>::const_iterator begin() const;
-    /// <summary>
-    /// Return iterator after the end of immutable sequence.
-    /// </summary>
-    /// <returns>Iterator after the end of immutable sequence.</returns>
-    std::vector<bool>::const_iterator end() const;
-    /// <summary>
-    /// Get the size of the data.
-    /// </summary>
-    /// <returns>Size of the data.</returns>
-    size_t size() const;
     /// <summary>
     /// Compares object with other
     /// </summary>
@@ -94,12 +57,5 @@ public:
     /// <param name="other">The other.</param>
     /// <returns>This instance.</returns>
     Individual& operator=(const Individual &other);
-    virtual ~Individual() = default;
-
-private:
-    /// <summary>
-    /// The binary representation of chromosome.
-    /// </summary>
-    std::vector<bool> m_BinaryData;
 };
 }

--- a/src/Spectre.libGenetic/Individual.h
+++ b/src/Spectre.libGenetic/Individual.h
@@ -36,20 +36,6 @@ public:
     explicit Individual(std::vector<bool> &&binaryData);
 
     /// <summary>
-    /// Gets the mutable data under specified index.
-    /// </summary>
-    /// <param name="index">The index.</param>
-    /// <returns>Single bit of data.</returns>
-    reference operator[](size_t index);
-
-    /// <summary>
-    /// Gets the immutable data under specified index.
-    /// </summary>
-    /// <param name="index">The index.</param>
-    /// <returns>Single bit of data.</returns>
-    const_reference operator[](size_t index) const;
-
-    /// <summary>
     /// Compares object with other
     /// </summary>
     /// <param name="other">The other.</param>

--- a/src/Spectre.libGenetic/MaximalFillupCondition.cpp
+++ b/src/Spectre.libGenetic/MaximalFillupCondition.cpp
@@ -28,7 +28,7 @@ MaximalFillupCondition::MaximalFillupCondition(size_t minimalFillup, std::unique
 
 bool MaximalFillupCondition::checkCurrentCondition(const spectre::algorithm::genetic::Individual &individual)
 {
-    size_t numberOfTrueValues = std::accumulate(individual.getData().begin(), individual.getData().end(), 0u);
+    size_t numberOfTrueValues = std::accumulate(individual.begin(), individual.end(), 0u);
     return numberOfTrueValues <= m_MaximalFillup;
 }
 

--- a/src/Spectre.libGenetic/MaximalPercentageFillupCondition.cpp
+++ b/src/Spectre.libGenetic/MaximalPercentageFillupCondition.cpp
@@ -28,7 +28,7 @@ MaximalPercentageFillupCondition::MaximalPercentageFillupCondition(double minima
 
 bool MaximalPercentageFillupCondition::checkCurrentCondition(const spectre::algorithm::genetic::Individual &individual)
 {
-    float numberOfTrueValues = std::accumulate(individual.getData().begin(), individual.getData().end(), 0.0f);
+    float numberOfTrueValues = std::accumulate(individual.begin(), individual.end(), 0.0f);
     return (numberOfTrueValues / individual.size()) <= m_MaximalPercentageFillup;
 }
 

--- a/src/Spectre.libGenetic/MinimalFillupCondition.cpp
+++ b/src/Spectre.libGenetic/MinimalFillupCondition.cpp
@@ -28,7 +28,7 @@ MinimalFillupCondition::MinimalFillupCondition(size_t minimalFillup, std::unique
 
 bool MinimalFillupCondition::checkCurrentCondition(const spectre::algorithm::genetic::Individual &individual)
 {
-    size_t numberOfTrueValues = std::accumulate(individual.getData().begin(), individual.getData().end(), 0u);
+    size_t numberOfTrueValues = std::accumulate(individual.begin(), individual.end(), 0u);
     return numberOfTrueValues >= m_MinimalFillup;
 }
 

--- a/src/Spectre.libGenetic/MinimalPercentageFillupCondition.cpp
+++ b/src/Spectre.libGenetic/MinimalPercentageFillupCondition.cpp
@@ -28,7 +28,7 @@ MinimalPercentageFillupCondition::MinimalPercentageFillupCondition(double minima
 
 bool MinimalPercentageFillupCondition::checkCurrentCondition(const spectre::algorithm::genetic::Individual &individual)
 {
-    float numberOfTrueValues = std::accumulate(individual.getData().begin(), individual.getData().end(), 0.0f);
+    float numberOfTrueValues = std::accumulate(individual.begin(), individual.end(), 0.0f);
     return (numberOfTrueValues / individual.size()) >= m_MinimalPercentageFillup;
 }
 

--- a/src/Spectre.libGenetic/ParentSelectionStrategy.cpp
+++ b/src/Spectre.libGenetic/ParentSelectionStrategy.cpp
@@ -42,7 +42,7 @@ reference_pair<Individual> ParentSelectionStrategy::next(Generation &generation,
     std::vector<ScoreType> defaultScores(scores.size(), 1);
     if (maxWeight <= 0)
     {
-        scores = defaultScores;
+        scores = gsl::make_span(defaultScores);
     }
     std::discrete_distribution<size_t> indexDistribution(scores.begin(), scores.end());
     const auto first = indexDistribution(m_RandomNumberGenerator);

--- a/src/Spectre.libGenetic/ParentSelectionStrategy.cpp
+++ b/src/Spectre.libGenetic/ParentSelectionStrategy.cpp
@@ -17,6 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include <algorithm>
 #include "Spectre.libGenetic/ParentSelectionStrategy.h"
 #include "Spectre.libException/ArgumentOutOfRangeException.h"
 #include "InconsistentGenerationAndScoresLengthException.h"
@@ -32,8 +33,8 @@ reference_pair<Individual> ParentSelectionStrategy::next(Generation &generation,
     {
         throw InconsistentGenerationAndScoresLengthException(generation.size(), scores.size());
     }
-    const auto minWeight = *std::min(scores.begin(), scores.end());
-    const auto maxWeight = *std::max(scores.begin(), scores.end());
+    const auto minWeight = *std::min_element(std::begin(scores), std::end(scores));
+    const auto maxWeight = *std::max_element(std::begin(scores), std::end(scores));
     if (minWeight < 0)
     {
         throw spectre::core::exception::ArgumentOutOfRangeException<ScoreType>("scores", 0, std::numeric_limits<ScoreType>::max(), minWeight);

--- a/src/Spectre.libGenetic/ParentSelectionStrategy.cpp
+++ b/src/Spectre.libGenetic/ParentSelectionStrategy.cpp
@@ -32,9 +32,8 @@ reference_pair<Individual> ParentSelectionStrategy::next(Generation &generation,
     {
         throw InconsistentGenerationAndScoresLengthException(generation.size(), scores.size());
     }
-    const auto minAndMaxWeights = std::minmax_element(scores.begin(), scores.end());
-    const auto minWeight = *minAndMaxWeights.first;
-    const auto maxWeight = *minAndMaxWeights.second;
+    const auto minWeight = *std::min(scores.begin(), scores.end());
+    const auto maxWeight = *std::max(scores.begin(), scores.end());
     if (minWeight < 0)
     {
         throw spectre::core::exception::ArgumentOutOfRangeException<ScoreType>("scores", 0, std::numeric_limits<ScoreType>::max(), minWeight);

--- a/src/Spectre.libGenetic/ParentSelectionStrategy.cpp
+++ b/src/Spectre.libGenetic/ParentSelectionStrategy.cpp
@@ -17,7 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-#include "ParentSelectionStrategy.h"
+#include "Spectre.libGenetic/ParentSelectionStrategy.h"
 #include "Spectre.libException/ArgumentOutOfRangeException.h"
 #include "InconsistentGenerationAndScoresLengthException.h"
 

--- a/src/Spectre.libPeakFinder.Tests/ExtremaFinderTest.cpp
+++ b/src/Spectre.libPeakFinder.Tests/ExtremaFinderTest.cpp
@@ -18,7 +18,7 @@
 */
 
 #include <gtest/gtest.h>
-#include "Spectre.libPeakFinder\ExtremaFinder.h"
+#include "Spectre.libPeakFinder/ExtremaFinder.h"
 
 namespace
 {

--- a/src/Spectre.libPeakFinder/ExtremaFinder.cpp
+++ b/src/Spectre.libPeakFinder/ExtremaFinder.cpp
@@ -18,8 +18,8 @@
 */
 #include <functional>
 #include "ExtremaFinder.h"
-#include "Spectre.libStatistics\Math.h"
-#include "Spectre.libFunctional\Filter.h"
+#include "Spectre.libStatistics/Math.h"
+#include "Spectre.libFunctional/Filter.h"
 
 namespace spectre::algorithm::peakfinder
 {

--- a/src/Spectre.libPeakFinder/ExtremaFinder.h
+++ b/src/Spectre.libPeakFinder/ExtremaFinder.h
@@ -18,7 +18,7 @@
 */
 
 #pragma once
-#include "Common\DataTypes.h"
+#include "Common/DataTypes.h"
 #include <vector>
 
 namespace spectre::algorithm::peakfinder

--- a/src/Spectre.libPeakFinder/FWHHCalculator.h
+++ b/src/Spectre.libPeakFinder/FWHHCalculator.h
@@ -19,7 +19,7 @@ limitations under the License.
 */
 
 #pragma once
-#include "Common\DataTypes.h"
+#include "Common/DataTypes.h"
 
 namespace spectre::algorithm::peakfinder
 {

--- a/src/Spectre.libStatistics/Math.h
+++ b/src/Spectre.libStatistics/Math.h
@@ -393,7 +393,7 @@ std::vector<DataType> build(size_t size, Generator generator)
 template <class DataType>
 std::vector<typename std::remove_const<DataType>::type> differentiate_unsafe(gsl::span<DataType> data, uint16_t order = 1)
 {
-    std::vector<std::remove_const<DataType>::type> result(data.begin(), data.end());
+    std::vector<typename std::remove_const<DataType>::type> result(data.begin(), data.end());
     for (auto i = 0u; i < order; ++i)
     {
         for (auto j = 0u; j < result.size() - 1; ++j)

--- a/src/Spectre.libStatistics/Math.h
+++ b/src/Spectre.libStatistics/Math.h
@@ -177,7 +177,7 @@ constexpr std::vector<DataType> min(gsl::span<const DataType> first, gsl::span<c
 /// <param name="second">The second.</param>
 /// <returns>Vector, elements of which are true, if corresponding elements in source vectors were equal.</returns>
 template<class DataType>
-constexpr std::vector<bool> equals(gsl::span<const DataType> first, gsl::span<const DataType> second, DataType* /*dummy*/ = static_cast<DataType *>(nullptr))
+std::vector<bool> equals(gsl::span<const DataType> first, gsl::span<const DataType> second, DataType* /*dummy*/ = static_cast<DataType *>(nullptr))
 {
     return spectre::core::functional::transform(first, second, [](DataType left, DataType right) { return left == right; }, static_cast<bool*>(nullptr));
 }
@@ -334,7 +334,7 @@ constexpr std::vector<DataType> min(gsl::span<const DataType> first, DataType se
 /// <param name="second">The second.</param>
 /// <returns>Vector which elements are true where elements of first were second.</returns>
 template<class DataType>
-constexpr std::vector<bool> equals(gsl::span<const DataType> first, DataType second)
+std::vector<bool> equals(gsl::span<const DataType> first, DataType second)
 {
     return spectre::core::functional::transform(first, [second](DataType left) { return left == second; }, static_cast<bool*>(nullptr));
 }

--- a/src/Spectre.libStatistics/Math.h
+++ b/src/Spectre.libStatistics/Math.h
@@ -18,6 +18,7 @@ limitations under the License.
 */
 
 #pragma once
+#include <cmath>
 #include <vector>
 #include <gsl/span>
 #include "Spectre.libFunctional/Transform.h"

--- a/src/Spectre.libStatistics/Statistics.h
+++ b/src/Spectre.libStatistics/Statistics.h
@@ -59,7 +59,7 @@ DataType Median(gsl::span<const DataType> data)
 {
     static_assert(std::is_arithmetic_v<DataType>, "DataType: expected arithmetic.");
     if (data.size() == 0) return static_cast<DataType>(0.0);
-    std::vector<std::remove_const<DataType>::type> sortedData(data.begin(), data.end());
+    std::vector<typename std::remove_const<DataType>::type> sortedData(data.begin(), data.end());
     std::sort(sortedData.begin(), sortedData.end());
     if (data.size() % 2) return sortedData[data.size() / 2];
     else return (sortedData[data.size() / 2] + sortedData[data.size() / 2 - 1]) / 2.0;

--- a/src/Spectre.libWavelet.Tests/ConvolutionTest.cpp
+++ b/src/Spectre.libWavelet.Tests/ConvolutionTest.cpp
@@ -18,8 +18,8 @@ limitations under the License.
 */
 
 #include <gtest/gtest.h>
-#include "Spectre.libWavelet\Convolution.h"
-#include "Spectre.libFunctional\Range.h"
+#include "Spectre.libWavelet/Convolution.h"
+#include "Spectre.libFunctional/Range.h"
 
 namespace
 {

--- a/src/Spectre.libWavelet.Tests/DaubechiesFiltersDenoiserTest.cpp
+++ b/src/Spectre.libWavelet.Tests/DaubechiesFiltersDenoiserTest.cpp
@@ -19,9 +19,9 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 #include "FloatingPointVectorMatcher.h"
-#include "Spectre.libWavelet\DaubechiesFiltersDenoiser.h"
-#include "Spectre.libWavelet\WaveletDecomposerRef.h"
-#include "Spectre.libWavelet\WaveletReconstructorRef.h"
+#include "Spectre.libWavelet/DaubechiesFiltersDenoiser.h"
+#include "Spectre.libWavelet/WaveletDecomposerRef.h"
+#include "Spectre.libWavelet/WaveletReconstructorRef.h"
 
 namespace
 {

--- a/src/Spectre.libWavelet.Tests/MedianAbsoluteDeviationNoiseEstimatorTest.cpp
+++ b/src/Spectre.libWavelet.Tests/MedianAbsoluteDeviationNoiseEstimatorTest.cpp
@@ -18,7 +18,7 @@ limitations under the License.
 */
 
 #include <gtest/gtest.h>
-#include "Spectre.libWavelet\MedianAbsoluteDeviationNoiseEstimator.h"
+#include "Spectre.libWavelet/MedianAbsoluteDeviationNoiseEstimator.h"
 
 namespace
 {

--- a/src/Spectre.libWavelet.Tests/SoftThresholderTest.cpp
+++ b/src/Spectre.libWavelet.Tests/SoftThresholderTest.cpp
@@ -19,10 +19,10 @@ limitations under the License.
 
 #include <gtest/gtest.h>
 #include "FloatingPointVectorMatcher.h"
-#include "Spectre.libFunctional\Range.h"
-#include "Spectre.libWavelet\SoftThresholder.h"
-#include "Spectre.libWavelet\WaveletDecomposerRef.h"
-#include "Spectre.libWavelet\MedianAbsoluteDeviationNoiseEstimator.h"
+#include "Spectre.libFunctional/Range.h"
+#include "Spectre.libWavelet/SoftThresholder.h"
+#include "Spectre.libWavelet/WaveletDecomposerRef.h"
+#include "Spectre.libWavelet/MedianAbsoluteDeviationNoiseEstimator.h"
 
 namespace
 {

--- a/src/Spectre.libWavelet.Tests/WaveletDecomposerRefTest.cpp
+++ b/src/Spectre.libWavelet.Tests/WaveletDecomposerRefTest.cpp
@@ -19,8 +19,8 @@ limitations under the License.
 */
 
 #include <gtest/gtest.h>
-#include "Spectre.libWavelet\WaveletDecomposerRef.h"
-#include "Spectre.libFunctional\Range.h"
+#include "Spectre.libWavelet/WaveletDecomposerRef.h"
+#include "Spectre.libFunctional/Range.h"
 #include "FloatingPointVectorMatcher.h"
 
 namespace

--- a/src/Spectre.libWavelet.Tests/WaveletReconstructorRefTest.cpp
+++ b/src/Spectre.libWavelet.Tests/WaveletReconstructorRefTest.cpp
@@ -19,9 +19,9 @@ limitations under the License.
 */
 
 #include <gtest/gtest.h>
-#include "Spectre.libWavelet\WaveletReconstructorRef.h"
-#include "Spectre.libWavelet\WaveletDecomposerRef.h"
-#include "Spectre.libFunctional\Range.h"
+#include "Spectre.libWavelet/WaveletReconstructorRef.h"
+#include "Spectre.libWavelet/WaveletDecomposerRef.h"
+#include "Spectre.libFunctional/Range.h"
 #include "FloatingPointVectorMatcher.h"
 
 namespace

--- a/src/Spectre.libWavelet/DataTypes.h
+++ b/src/Spectre.libWavelet/DataTypes.h
@@ -18,7 +18,7 @@
 */
 #pragma once
 #include <vector>
-#include "Common\DataTypes.h"
+#include "Common/DataTypes.h"
 
 namespace spectre::algorithm::wavelet
 {

--- a/src/Spectre.libWavelet/SoftThresholder.cpp
+++ b/src/Spectre.libWavelet/SoftThresholder.cpp
@@ -16,6 +16,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 */
+#include <cmath>
 #include "Spectre.libFunctional/Transform.h"
 #include "SoftThresholder.h"
 

--- a/src/Spectre.libWavelet/WaveletDecomposerRef.h
+++ b/src/Spectre.libWavelet/WaveletDecomposerRef.h
@@ -41,7 +41,7 @@ public:
     WaveletCoefficients Decompose(Data&& signal) const;
 
 private:
-    inline void WaveletDecomposerRef::ApplyFilters(
+    inline void ApplyFilters(
         WaveletCoefficients& coefficients,
         CoefficientsPerLevel& lowFrequencyCoefficients,
         size_t scale, size_t blockLength, unsigned level) const;

--- a/src/Spectre.libWavelet/WaveletReconstructorRef.cpp
+++ b/src/Spectre.libWavelet/WaveletReconstructorRef.cpp
@@ -23,6 +23,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
+#include <cstring>
 #include "PrecomputedDaubechiesCoefficients.h"
 #include "WaveletReconstructorRef.h"
 #include "WaveletUtils.h"

--- a/src/Spectre.libWavelet/WaveletReconstructorRef.h
+++ b/src/Spectre.libWavelet/WaveletReconstructorRef.h
@@ -42,7 +42,7 @@ public:
     Data Reconstruct(WaveletCoefficients&& coefficients, size_t signalLength) const;
 
 private:
-    inline void WaveletReconstructorRef::ApplyFilters(
+    inline void ApplyFilters(
         WaveletCoefficients& coefficients, size_t scale,
         size_t blockLength, unsigned level) const;
 


### PR DESCRIPTION
**Summary**
This merge request adds CMake configuration to the project, enabling Linux builds.

**Prerequisites**
Requires #45 to be merged and source branch to be rebased on top of this merge.

**Scope**
To enable GCC/Clang builds and refactor existing code while preserving MSVC compatibility.

The possibility of *replacing* existing MSVC solution in favor of CMake was not addressed in this pull request *at all*, as the current scope turned out broad already. It is a future goal to *regenerate* MSVC solution from CMake configuration on Windows when the CMake configuration proves sufficient.

**Addressed problems**
- Providing Linux-oriented CMake configuration.
- Fixing of non-portable include paths.
- Removing extra qualification in header files.
- Adding missing header imports.
- Updating unit tests not to be platform-dependent (RNG).
- Refactoring of Individual class to actually inherit std::vector<bool> to overcome problems with overloaded operators.
- Resolving linker errors related to internal (project/project) and external (OpenMP) dependencies.

CMake project configuration lists all project files instead of globbing them. This is the preferred solution because of discoverability problems connected with glob usage; think *explicit is better than implicit*. See https://stackoverflow.com/a/1060061 for further discussion.

**Environment & dependencies**
Project was confirmed to build under GCC ≥ 7.2 and Clang ≥ 5.0 compilers. Changes were tested under up-to-date Debian unstable setup, as well as with Debian testing Docker image.

In order to build the project, the following minimal set of packages needs to be installed (current versions of Debian unstable packages in brackets):
- build-essential — gcc/g++/make tooling [12.5], with default GCC 7 compiler [7.3.0-17]
- g++-8 — required for GCC 8 builds [8.1.0]
- clang-5.0/clang-6.0/clang-7 — required for Clang builds [7~svn323616-1]
- cmake — CMake toolset [3.11.1]
- cmake-extras — additional CMake finders [1.3+17.04.20170310-1]; bundles GMock finder
- libgmock-dev — GMock/GTest library [1.8.0-10]
- libmsgsl-dev — Microsoft GSL header-only library [0~git20170602.1f87ef7-2]
- libomp-dev — Clang’s OpenMP implementation [6.0-2]
- libopencv-dev — OpenCV library [3.2.0+dfsg-4+b4]

**Testing**
One can test the configuration by issuing:
```sh
# make sure deps are installed
apt-get -qq update && apt-get -qq install build-essential [ clang-7 ] [ g++-8 ] \
    cmake cmake-extras libgmock-dev libmsgsl-dev libomp-dev libopencv-dev

# prepare build directory
mkdir -p build && cd build

# select Clang compiler
export CC="/usr/bin/clang-7"     # or: clang-5.0, clang-6.0
export CXX="/usr/bin/clang++-7"  # or: clang++-5.0, clang++-6.0

# or: select GCC compiler
export CC="/usr/bin/gcc-7"       # or: gcc-8
export CXX="/usr/bin/g++-7"      # or: g++-8

# generate project files, build & run unit tests
cmake ..
cmake --build . -- -j$(nproc)
ctest --output-on-failure -j$(nproc)

# or: using make only; ARGS go to ctest
cmake ..
make -j$(nproc) all test ARGS="--output-on-failure -j$(nproc)"
```

**Note to reviewers**
- Make sure the prerequisite described above is already satisfied.
- Again, as the pull request affects the whole project, I am adding more reviewers and requesting authors of specific components to pay special attention to changes impacting their code. Please don’t go through all the code unless you have superhuman powers.
- Please prefer going through the commits one-by-one instead of jumping into the cumulative diff, as it is huge; you have been warned.

Thanks!