### PR TITLE
Provide Dockerfiles for local build testing with GCC/Clang

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+build/
+cmake-build*/
+src/packages/

--- a/contrib/docker-build/README.md
+++ b/contrib/docker-build/README.md
@@ -1,0 +1,47 @@
+# Docker-based build images
+
+Meant for local testing, before sending changes to Travis CI.
+
+## Usage
+
+Run commands from repository root. Successful image build acts as a smoke test.
+
+Local installation of Docker is required.
+
+### GCC
+
+```sh
+docker build \
+  -f contrib/docker-build/gcc.Dockerfile \
+  -t spectre/native-alg:gcc \
+[ --build-arg=GCC_VERSION=7 ] \
+  .
+```
+
+Valid values for `GCC_VERSION` as listed in <https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test>. Default shown.
+
+### Clang
+
+```sh
+docker build \
+  -f contrib/docker-build/clang.Dockerfile \
+  -t spectre/native-alg:clang \
+[ --build-arg=CLANG_VERSION=5.0 ] \
+  .
+```
+
+Valid values for `CLANG_VERSION` as listed in <http://apt.llvm.org/trusty/dists/>. Default shown.
+
+## Cleanup
+
+Remember to remove excess images. You may consult image list with:
+
+```sh
+docker images
+```
+
+and remove selected ones with:
+
+```sh
+docker rmi IMAGE...
+```

--- a/contrib/docker-build/clang.Dockerfile
+++ b/contrib/docker-build/clang.Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:trusty
+
+# You need to use `llvm-toolchain-trusty' (without version) for latest Clang
+ARG CLANG_VERSION=5.0
+
+## Deps phase ##
+
+RUN echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main" | tee /etc/apt/sources.list.d/ubuntu-toolchain.list \
+ && echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-${CLANG_VERSION} main" | tee /etc/apt/sources.list.d/llvm-toolchain.list \
+ && echo "deb http://ppa.launchpad.net/lkoppel/opencv/ubuntu trusty main" | tee /etc/apt/sources.list.d/opencv.list \
+ && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 15CF4D18AF4F7421 98749F984560FB8A 1E9377A2BA9EF27F \
+ && apt-get -qq update \
+ && apt-get install -qq \
+    build-essential \
+    clang-${CLANG_VERSION} \
+    gdb \
+    git \
+    libstdc++-7-dev \
+    libopencv-dev \
+    libiomp-dev \
+    strace \
+    wget \
+ && wget https://cmake.org/files/v3.11/cmake-3.11.2-Linux-x86_64.sh \
+ && sh cmake-3.11.2-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
+
+## Build phase ##
+
+WORKDIR /data
+COPY . /data
+
+RUN mkdir build \
+ && cd build \
+ && export CC="/usr/bin/clang-${CLANG_VERSION}" \
+ && export CXX="/usr/bin/clang++-${CLANG_VERSION}" \
+ && cmake .. \
+ && cmake --build . -- -j$(nproc) \
+ && ctest --output-on-failure -j$(nproc)

--- a/contrib/docker-build/gcc.Dockerfile
+++ b/contrib/docker-build/gcc.Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:trusty
+
+ARG GCC_VERSION=7
+
+## Deps phase ##
+
+RUN echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main" | tee /etc/apt/sources.list.d/ubuntu-toolchain.list \
+ && echo "deb http://ppa.launchpad.net/lkoppel/opencv/ubuntu trusty main" | tee /etc/apt/sources.list.d/opencv.list \
+ && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 98749F984560FB8A 1E9377A2BA9EF27F \
+ && apt-get -qq update \
+ && apt-get install -qq \
+    build-essential \
+    g++-${GCC_VERSION} \
+    gdb \
+    git \
+    libstdc++-7-dev \
+    libopencv-dev \
+    libiomp-dev \
+    strace \
+    wget \
+ && wget https://cmake.org/files/v3.11/cmake-3.11.2-Linux-x86_64.sh \
+ && sh cmake-3.11.2-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
+
+## Build phase ##
+
+WORKDIR /data
+COPY . /data
+
+RUN mkdir build \
+ && cd build \
+ && export CC="/usr/bin/gcc-${GCC_VERSION}" \
+ && export CXX="/usr/bin/g++-${GCC_VERSION}" \
+ && cmake .. \
+ && cmake --build . -- -j$(nproc) \
+ && ctest --output-on-failure -j$(nproc)


### PR DESCRIPTION
Please consult contrib/docker-build/README.md for usage info.

Added .dockerignore file to globally exclude build artifact directories
when attempting an image build. This heavily affects output image size.

Dockerfile build instructions are divided into two RUN commands: for
dependencies and proper build script; this has a possitive effect on
rebuild time, as the first RUN creates an intermediate container with
all required dependencies, while the second RUN is always refreshed
with new files from repository, before a C++ build is attempted.